### PR TITLE
[ID-20] 마이페이지 - 회원 탈퇴, 회원 정보 수정 api 연동

### DIFF
--- a/idearly/src/hooks/useLoginMutation.ts
+++ b/idearly/src/hooks/useLoginMutation.ts
@@ -5,11 +5,13 @@ import { useNavigate } from "react-router-dom";
 import { useToast } from "@chakra-ui/react";
 import { useSetAtom } from "jotai";
 import { LoginStateAtom } from "../store/LoginPage.atoms";
+import { userInfoAtom } from "../store";
 
 export const useLoginMutation = () => {
   const navigate = useNavigate();
   const toast = useToast();
   const setIsLoginState = useSetAtom(LoginStateAtom);
+  const setUsrInfoState = useSetAtom(userInfoAtom);
 
   return useMutation({
     mutationFn: (userInfo: IUserRequest) => loginUser(userInfo),
@@ -25,8 +27,10 @@ export const useLoginMutation = () => {
     },
     onSuccess: (data) => {
       console.log(data);
+      console.log(data.data.result);
       // 로그인 상태 업데이트
       setIsLoginState(true);
+      setUsrInfoState(data.data.result);
       toast({
         title: "로그인 성공!",
         description: "로그인에 성공하였습니다!",

--- a/idearly/src/hooks/useLoginMutation.ts
+++ b/idearly/src/hooks/useLoginMutation.ts
@@ -11,7 +11,7 @@ export const useLoginMutation = () => {
   const navigate = useNavigate();
   const toast = useToast();
   const setIsLoginState = useSetAtom(LoginStateAtom);
-  const setUsrInfoState = useSetAtom(userInfoAtom);
+  const setUserInfoState = useSetAtom(userInfoAtom);
 
   return useMutation({
     mutationFn: (userInfo: IUserRequest) => loginUser(userInfo),
@@ -30,7 +30,7 @@ export const useLoginMutation = () => {
       console.log(data.data.result);
       // 로그인 상태 업데이트
       setIsLoginState(true);
-      setUsrInfoState(data.data.result);
+      setUserInfoState(data.data.result);
       toast({
         title: "로그인 성공!",
         description: "로그인에 성공하였습니다!",

--- a/idearly/src/hooks/useLogoutMutation.ts
+++ b/idearly/src/hooks/useLogoutMutation.ts
@@ -4,11 +4,14 @@ import { useToast } from "@chakra-ui/react";
 import { useNavigate } from "react-router-dom";
 import { useSetAtom } from "jotai";
 import { LoginStateAtom } from "../store/LoginPage.atoms";
+import { userInfoAtom } from "../store";
 
 export const useLogoutMutation = () => {
   const toast = useToast();
   const navigate = useNavigate();
   const setIsLoginState = useSetAtom(LoginStateAtom);
+  const setUserInfoState = useSetAtom(userInfoAtom);
+  
   return useMutation({
     mutationFn: () => logoutUser(),
     onError: (error) => {
@@ -17,6 +20,11 @@ export const useLogoutMutation = () => {
     onSuccess: (data) => {
       console.log(data);
       setIsLoginState(false);
+      setUserInfoState({
+        memberId: '',
+        email: '',
+        name: '',
+      });
       toast({
         title: "로그아웃 완료",
         description: "로그아웃 완료되었습니다.",

--- a/idearly/src/hooks/useMyPageMutation.ts
+++ b/idearly/src/hooks/useMyPageMutation.ts
@@ -4,6 +4,7 @@ import { useToast } from "@chakra-ui/react";
 import { useSetAtom } from "jotai";
 import { LoginStateAtom } from "../store/LoginPage.atoms";
 import { modifyUser, withdrawalUser } from "../services/apis/mypage.apis";
+import { userInfoAtom } from "../store";
 
 export const useWithdrawalMutation = () => {
   const setIsLoginState = useSetAtom(LoginStateAtom);
@@ -44,6 +45,7 @@ export const useWithdrawalMutation = () => {
 export const useModifyUerMutation = () => {
   const toast = useToast();
   const navigate = useNavigate();
+  const setUserInfoState = useSetAtom(userInfoAtom);
 
   return useMutation({
     mutationFn: (name: string) => modifyUser(name),
@@ -58,7 +60,12 @@ export const useModifyUerMutation = () => {
       });
     },
     onSuccess: (data) => {
-      console.log(data);
+      console.log('check: ', data);
+      console.log('check: ', data.data.data.name);
+
+      // 이 부분도 storage에 저장해야되겠죠?
+      setUserInfoState((prev) => ({ ...prev, name: data.data.data.name }));
+
       toast({
         title: "회원 정보 수정 성공",
         description: "회원 정보 수정에 성공하였습니다!",

--- a/idearly/src/hooks/useMyPageMutation.ts
+++ b/idearly/src/hooks/useMyPageMutation.ts
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useToast } from "@chakra-ui/react";
 import { useSetAtom } from "jotai";
 import { LoginStateAtom } from "../store/LoginPage.atoms";
-import { withdrawalUser } from "../services/apis/mypage.apis";
+import { modifyUser, withdrawalUser } from "../services/apis/mypage.apis";
 
 export const useWithdrawalMutation = () => {
   const setIsLoginState = useSetAtom(LoginStateAtom);
@@ -34,6 +34,38 @@ export const useWithdrawalMutation = () => {
         isClosable: true,
       });
 
+      setTimeout(() => {
+        navigate("/");
+      }, 1000);
+    },
+  });
+};
+
+export const useModifyUerMutation = () => {
+  const toast = useToast();
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: (name: string) => modifyUser(name),
+    onError: (error) => {
+      console.error(error);
+      toast({
+        title: "회원 정보 수정 실패",
+        description: "다시 시도해주세요.",
+        status: "error",
+        duration: 1000,
+        isClosable: true,
+      });
+    },
+    onSuccess: (data) => {
+      console.log(data);
+      toast({
+        title: "회원 정보 수정 성공",
+        description: "회원 정보 수정에 성공하였습니다!",
+        status: "success",
+        duration: 2000,
+        isClosable: true,
+      });
       setTimeout(() => {
         navigate("/");
       }, 1000);

--- a/idearly/src/hooks/useMyPageMutation.ts
+++ b/idearly/src/hooks/useMyPageMutation.ts
@@ -8,6 +8,8 @@ import { userInfoAtom } from "../store";
 
 export const useWithdrawalMutation = () => {
   const setIsLoginState = useSetAtom(LoginStateAtom);
+  const setUserInfoState = useSetAtom(userInfoAtom);
+
   const navigate = useNavigate();
   const toast = useToast();
 
@@ -27,6 +29,11 @@ export const useWithdrawalMutation = () => {
       console.log(data);
       // 로그인 상태 업데이트
       setIsLoginState(false);
+      setUserInfoState({
+        memberId: '',
+        email: '',
+        name: '',
+      });
       toast({
         title: "회원 탈퇴 성공",
         description: "탈퇴에 성공하였습니다!",

--- a/idearly/src/hooks/useMyPageMutation.ts
+++ b/idearly/src/hooks/useMyPageMutation.ts
@@ -1,0 +1,42 @@
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+import { useToast } from "@chakra-ui/react";
+import { useSetAtom } from "jotai";
+import { LoginStateAtom } from "../store/LoginPage.atoms";
+import { withdrawalUser } from "../services/apis/mypage.apis";
+
+export const useWithdrawalMutation = () => {
+  const setIsLoginState = useSetAtom(LoginStateAtom);
+  const navigate = useNavigate();
+  const toast = useToast();
+
+  return useMutation({
+    mutationFn: () => withdrawalUser(),
+    onError: (error) => {
+      console.error(error);
+      toast({
+        title: "회원 탈퇴 실패",
+        description: "다시 시도해주세요.",
+        status: "error",
+        duration: 1000,
+        isClosable: true,
+      });
+    },
+    onSuccess: (data) => {
+      console.log(data);
+      // 로그인 상태 업데이트
+      setIsLoginState(false);
+      toast({
+        title: "회원 탈퇴 성공",
+        description: "탈퇴에 성공하였습니다!",
+        status: "success",
+        duration: 2000,
+        isClosable: true,
+      });
+
+      setTimeout(() => {
+        navigate("/");
+      }, 1000);
+    },
+  });
+};

--- a/idearly/src/layout/Header/Header.tsx
+++ b/idearly/src/layout/Header/Header.tsx
@@ -4,13 +4,16 @@ import { AlgorithmHeaderConfig, MainHeaderConfig } from "../../constants";
 import { useEffect } from "react";
 import { useLogoutMutation } from "../../hooks";
 import axios from "axios";
-import { useAtom } from "jotai";
+import { useAtom, useSetAtom } from "jotai";
 import { LoginStateAtom } from "../../store/LoginPage.atoms";
+import { userInfoAtom } from "../../store";
 
 export const Header = () => {
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const [isLoginState, setIsLoginState] = useAtom(LoginStateAtom);
+  const setUserInfoState = useSetAtom(userInfoAtom);
+
   const isAlgorithmPage = pathname.startsWith("/algorithm-solving");
 
   const handleMoveToPath = (path: string) => {
@@ -29,6 +32,11 @@ export const Header = () => {
       (error) => {
         if (error.response && error.response.status === 401) {
           setIsLoginState(false);
+          setUserInfoState({
+            memberId: '',
+            email: '',
+            name: '',
+          });
         }
         return Promise.reject(error);
       }

--- a/idearly/src/pages/AlgorithmSolvingPage/components/AlgorithmTextChatModal/AlgorithmTextChatModal.tsx
+++ b/idearly/src/pages/AlgorithmSolvingPage/components/AlgorithmTextChatModal/AlgorithmTextChatModal.tsx
@@ -46,9 +46,6 @@ export const AlgorithmTextChatModal = ({isOpen, onClose}: Prop) => {
       debug: function (str: string) {
         console.log(str);
       },
-      // connectHeaders: {
-      //   // accessToken: window.localStorage.getItem('authorization'),
-      // },
       onConnect: () => {   // 연결됐을때 실행할 함수
         console.log('success');
         subscribe(); // 연결 성공 시 구독하는 로직

--- a/idearly/src/pages/MyPage/components/MyPageModifyInfo/MyPageModifyInfo.tsx
+++ b/idearly/src/pages/MyPage/components/MyPageModifyInfo/MyPageModifyInfo.tsx
@@ -1,18 +1,28 @@
 import { Button, Card, CardBody, CardFooter, CardHeader, Heading } from "@chakra-ui/react"
 import * as S from "./MyPageModifyInfo.styles";
+import { useModifyUerMutation } from "../../../../hooks/useMyPageMutation";
+import { useState } from "react";
 
 export const MyPageModifyInfo = () => {
+  const [value, setValue] = useState('');
+  const { mutate } = useModifyUerMutation();
+  
+  const handleSubmit = () => {
+    mutate(value);
+    setValue('');
+  }
   return (
     <S.CardWrapper>
       <Card align='center'>
         <CardHeader>
           <Heading size='md'> 이름 변경</Heading>
         </CardHeader>
+        {/* 이 부분 form으로 변경해야할까요? */}
         <CardBody>
-          <S.ModifyInput placeholder='변경할 이름을 입력해주세요.' />
+          <S.ModifyInput placeholder='변경할 이름을 입력해주세요.' value={value} onChange={(e) => setValue(e.target.value)} />
         </CardBody>
         <CardFooter>
-          <Button colorScheme='blue'>수정</Button>
+          <Button colorScheme='blue' onClick={handleSubmit}>수정</Button>
         </CardFooter>
       </Card>
     </S.CardWrapper>

--- a/idearly/src/pages/MyPage/components/MyPageWithdrawal/MyPageWithdrawal.tsx
+++ b/idearly/src/pages/MyPage/components/MyPageWithdrawal/MyPageWithdrawal.tsx
@@ -1,10 +1,16 @@
 import { MyPageWithdrawalConfig } from "../../../../constants/MyPage.constants";
+import { useWithdrawalMutation } from "../../../../hooks/useMyPageMutation";
 import * as S from "./MyPageWithdrawal.styles";
 import { useState } from "react";
 
 export const MyPageWithdrawal = () => {
+  const { mutate } = useWithdrawalMutation();
   const [isCheck, setIsCheck] = useState(false);
   const {title1, content1, title2, content2, title3, content3, title4, title5, content5} = MyPageWithdrawalConfig;
+
+  const handleClick = () => {
+    mutate();
+  }
   
   return (
     <S.WithdrawalContainer>
@@ -32,7 +38,7 @@ export const MyPageWithdrawal = () => {
         {isCheck ? "radio_button_checked" : "radio_button_unchecked"}
         <div>회원 탈퇴를 진행하며 해당 계정에 귀속된 모든 정보를 삭제하는데 동의합니다.</div>
       </S.RadioIcon>
-      <S.WithdrawalBtn isDisabled={!isCheck} colorScheme="red">회원 탈퇴하기</S.WithdrawalBtn>
+      <S.WithdrawalBtn isDisabled={!isCheck} colorScheme="red" onClick={handleClick}>회원 탈퇴하기</S.WithdrawalBtn>
     </S.WithdrawalContainer>
   )
 }

--- a/idearly/src/services/apis/mypage.apis.ts
+++ b/idearly/src/services/apis/mypage.apis.ts
@@ -4,3 +4,8 @@ import { axiosInstance } from "./axios";
 export const withdrawalUser = async () => {
   return await axiosInstance.delete("/api/members");
 }
+
+// 회원 정보 수정 요청
+export const modifyUser = async (name: string) => {
+  return await axiosInstance.patch("/api/members", name);
+}

--- a/idearly/src/services/apis/mypage.apis.ts
+++ b/idearly/src/services/apis/mypage.apis.ts
@@ -1,0 +1,6 @@
+import { axiosInstance } from "./axios";
+
+// 회원 탈퇴 요청
+export const withdrawalUser = async () => {
+  return await axiosInstance.delete("/api/members");
+}

--- a/idearly/src/store/UserInfo.atoms.ts
+++ b/idearly/src/store/UserInfo.atoms.ts
@@ -1,7 +1,6 @@
-import { atom } from "jotai";
-import type { IUserInfoResponse } from "../types";
+import { atomWithStorage } from "jotai/utils";
 
-export const userInfoAtom = atom<IUserInfoResponse>({
+export const userInfoAtom = atomWithStorage("userInfo", {
   memberId: '',
   email: '',
   name: '',


### PR DESCRIPTION
## 이슈 번호
ID-20
- 📌

## 작업 분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 기타

## 작업 상세 내용
- 회원 탈퇴 api 연동
- 회원 정보 수정 api 연동
- 로그인 시 회원 정보 전역 변수로 관리

## 다음 할 일
- 로그인 시 회원 정보 storage로 저장
- 현재 팀 조회 api 연동

## 체크 리스트

- [x] main 브랜치 pull 받기
- [x] 아직 작업 중인 파일은 올리지 않기

## 질문 사항

💬 **질문이 있어요!**
- 회원 정보 변경 같은 경우, form으로 감싸는게 좋을까요?
- 회원 정보는 그냥 jotai로만 저장하면 새로고침 시 날아가는데, storage에 저장하는게 맞을까요?

🔴 **이건 반드시 확인해 주세요!**
