### PR TITLE
[ID-20] 마이페이지 현재 팀 조회 api 연동

### DIFF
--- a/idearly/src/hooks/useLoginMutation.ts
+++ b/idearly/src/hooks/useLoginMutation.ts
@@ -26,7 +26,6 @@ export const useLoginMutation = () => {
     onSuccess: (data) => {
       // 로그인 상태 업데이트
       const isUser = data.data.result.authority === "USER";
-      console.log(isUser);
       setUserInfoState({ ...data.data.result, isLogin: true });
       toast({
         title: "로그인 성공!",

--- a/idearly/src/hooks/useLogoutMutation.ts
+++ b/idearly/src/hooks/useLogoutMutation.ts
@@ -9,7 +9,7 @@ export const useLogoutMutation = () => {
   const toast = useToast();
   const navigate = useNavigate();
   const setUserInfoState = useSetAtom(userInfoAtom);
-  
+
   return useMutation({
     mutationFn: () => logoutUser(),
     onError: (error) => {
@@ -19,9 +19,10 @@ export const useLogoutMutation = () => {
       console.log(data);
       // setIsLoginState(false);
       setUserInfoState({
-        memberId: '',
-        email: '',
-        name: '',
+        authority: "",
+        memberId: "",
+        email: "",
+        name: "",
         isLogin: false,
       });
       toast({

--- a/idearly/src/hooks/useLogoutMutation.ts
+++ b/idearly/src/hooks/useLogoutMutation.ts
@@ -17,7 +17,6 @@ export const useLogoutMutation = () => {
     },
     onSuccess: (data) => {
       console.log(data);
-      // setIsLoginState(false);
       setUserInfoState({
         authority: "",
         memberId: "",

--- a/idearly/src/hooks/useMyPageMutation.ts
+++ b/idearly/src/hooks/useMyPageMutation.ts
@@ -142,15 +142,14 @@ export const useHandleInviteMutation = () => {
 
 export const useTeamInfoQuery = (isClick: boolean, teamId: number) => {
   const {
-    data,
-    status,
-    isInitialLoading,
+    data: memberData,
     error,
+    isLoading,
   } = useQuery({
     queryKey: ["teamInfo", teamId],
     queryFn:() => getTeamInfo(teamId),
     enabled: isClick,
-    staleTime: 2 * 1000,
+    // staleTime: 2 * 1000,
   });
-  return { data, status, error, isInitialLoading };
+  return { memberData, error, isLoading };
 }

--- a/idearly/src/hooks/useMyPageMutation.ts
+++ b/idearly/src/hooks/useMyPageMutation.ts
@@ -3,8 +3,9 @@ import { useNavigate } from "react-router-dom";
 import { useToast } from "@chakra-ui/react";
 
 import { useAtom, useSetAtom } from "jotai";
-import { handleInvite, getCWaitTeam, getCurrentTeam, modifyUser, withdrawalUser, getTeamInfo } from "../services/apis/mypage.apis";
+import { handleInvite, getCWaitTeam, getCurrentTeam, modifyUser, withdrawalUser, getTeamInfo, ModifyTeamMembers } from "../services/apis/mypage.apis";
 import { curTeamAtom, userInfoAtom, waitTeamAtom } from "../store";
+import { IReqTeamMember } from "../types";
 
 export const useWithdrawalMutation = () => {
   const setUserInfoState = useSetAtom(userInfoAtom);
@@ -118,7 +119,7 @@ interface IHandleInvite {
 }
 
 export const useHandleInviteMutation = () => {
-  const [curTeam, setCurTeam] = useAtom(curTeamAtom);
+  const setCurTeam = useSetAtom(curTeamAtom);
   const [waitTeam, setWaitTeam] = useAtom(waitTeamAtom);
 
   return useMutation({
@@ -153,3 +154,35 @@ export const useTeamInfoQuery = (isClick: boolean, teamId: number) => {
   });
   return { memberData, error, isLoading };
 }
+interface ITeamMember {
+  teamId: number;
+  payload: IReqTeamMember[]
+
+}
+export const useModifyTeamMembersMutation = () => {
+  const toast = useToast();
+
+  return useMutation({
+    mutationFn: ({teamId, payload}: ITeamMember) => ModifyTeamMembers(teamId, payload),
+    onError: (error) => {
+      console.error(error);
+      toast({
+        title: "팀원 수정 실패",
+        description: "다시 시도해주세요.",
+        status: "error",
+        duration: 1000,
+        isClosable: true,
+      });
+    },
+    onSuccess: (data) => {
+      console.log(data);
+      toast({
+        title: "팀원 수정 성공",
+        description: "팀원 정보를 수정하였습니다!",
+        status: "success",
+        duration: 2000,
+        isClosable: true,
+      });
+    },
+  });
+};

--- a/idearly/src/hooks/useMyPageMutation.ts
+++ b/idearly/src/hooks/useMyPageMutation.ts
@@ -140,16 +140,17 @@ export const useHandleInviteMutation = () => {
   });
 };
 
-export const useTeamInfoQuery = (teamId: number) => {
+export const useTeamInfoQuery = (isClick: boolean, teamId: number) => {
   const {
     data,
     status,
+    isInitialLoading,
     error,
-    refetch,
   } = useQuery({
     queryKey: ["teamInfo", teamId],
     queryFn:() => getTeamInfo(teamId),
+    enabled: isClick,
     staleTime: 2 * 1000,
   });
-  return { data, status, error, refetch };
+  return { data, status, error, isInitialLoading };
 }

--- a/idearly/src/hooks/useMyPageMutation.ts
+++ b/idearly/src/hooks/useMyPageMutation.ts
@@ -127,20 +127,9 @@ export const useHandleInviteMutation = () => {
       console.error(error);
     },
     onSuccess: (data) => {
-      // 반환값을 보고, 이게 수락인지 거절인지 확인 후, 리스트에서 처리
-      // 반환값에 해당 TeamId도 같이 건내주면 좋겠다!
-      console.log('res: ', data);
-      console.log('res: ', data.data);
-      console.log('res: ', data.data.accept);
-
-      // 수락이라면, 대기현황에서 삭제, 현재 팀으로 이동
-      // 거절이라면, 대기 현황에서 삭제
       if (data.data.accept) {
         console.log('수락');
-        // teamId를 필터링해서 삭제.
-        console.log('teamID', data.data.teamId);
         const accetedTeam = waitTeam.filter((team) => team.teamId == data.data.teamId)[0];
-        console.log("accetedTeam: ", accetedTeam);
         setCurTeam((prev) => [...prev, accetedTeam])
         setWaitTeam((prev) => prev.filter((team) => team.teamId == data.data.teamId));
       } else {

--- a/idearly/src/hooks/useMyPageMutation.ts
+++ b/idearly/src/hooks/useMyPageMutation.ts
@@ -3,7 +3,15 @@ import { useNavigate } from "react-router-dom";
 import { useToast } from "@chakra-ui/react";
 
 import { useAtom, useSetAtom } from "jotai";
-import { handleInvite, getCWaitTeam, getCurrentTeam, modifyUser, withdrawalUser, getTeamInfo, ModifyTeamMembers } from "../services/apis/mypage.apis";
+import {
+  handleInvite,
+  getCWaitTeam,
+  getCurrentTeam,
+  modifyUser,
+  withdrawalUser,
+  getTeamInfo,
+  ModifyTeamMembers,
+} from "../services/apis/mypage.apis";
 import { curTeamAtom, userInfoAtom, waitTeamAtom } from "../store";
 import { IReqTeamMember } from "../types";
 
@@ -88,34 +96,26 @@ export const useModifyUerMutation = () => {
 };
 
 export const useGetCurrentTeamQuery = () => {
-  const {
-    data,
-    status,
-    error,
-  } = useQuery({
+  const { data, status, error } = useQuery({
     queryKey: ["curTeam"],
     queryFn: getCurrentTeam,
-    staleTime: 2 * 60 * 1000,
+    staleTime: 5 * 1000,
   });
   return { data, status, error };
 };
 
 export const useGetWaitTeamQuery = () => {
-  const {
-    data,
-    status,
-    error,
-  } = useQuery({
+  const { data, status, error } = useQuery({
     queryKey: ["waitTeam"],
     queryFn: getCWaitTeam,
-    staleTime: 2 * 60 * 1000,
+    staleTime: 5 * 1000,
   });
   return { data, status, error };
 };
 
 interface IHandleInvite {
-  teamId: number,
-  isAccept: boolean,
+  teamId: number;
+  isAccept: boolean;
 }
 
 export const useHandleInviteMutation = () => {
@@ -123,47 +123,50 @@ export const useHandleInviteMutation = () => {
   const [waitTeam, setWaitTeam] = useAtom(waitTeamAtom);
 
   return useMutation({
-    mutationFn: ({teamId, isAccept}: IHandleInvite) => handleInvite(teamId, isAccept),
+    mutationFn: ({ teamId, isAccept }: IHandleInvite) =>
+      handleInvite(teamId, isAccept),
     onError: (error) => {
       console.error(error);
     },
     onSuccess: (data) => {
       if (data.data.accept) {
-        console.log('수락');
-        const accetedTeam = waitTeam.filter((team) => team.teamId == data.data.teamId)[0];
-        setCurTeam((prev) => [...prev, accetedTeam])
-        setWaitTeam((prev) => prev.filter((team) => team.teamId == data.data.teamId));
+        console.log("수락");
+        const accetedTeam = waitTeam.filter(
+          (team) => team.teamId == data.data.teamId
+        )[0];
+        setCurTeam((prev) => [...prev, accetedTeam]);
+        setWaitTeam((prev) =>
+          prev.filter((team) => team.teamId == data.data.teamId)
+        );
       } else {
-        console.log('거절');
-        setWaitTeam((prev) => prev.filter((team) => team.teamId == data.data.teamId));
+        console.log("거절");
+        setWaitTeam((prev) =>
+          prev.filter((team) => team.teamId == data.data.teamId)
+        );
       }
     },
   });
 };
 
 export const useTeamInfoQuery = (isClick: boolean, teamId: number) => {
-  const {
-    data: memberData,
-    error,
-    isLoading,
-  } = useQuery({
+  const { data, error, isLoading } = useQuery({
     queryKey: ["teamInfo", teamId],
-    queryFn:() => getTeamInfo(teamId),
+    queryFn: () => getTeamInfo(teamId),
     enabled: isClick,
     staleTime: 2 * 60 * 1000,
   });
-  return { memberData, error, isLoading };
-}
+  return { data, error, isLoading };
+};
 interface ITeamMember {
   teamId: number;
-  payload: IReqTeamMember[]
-
+  payload: IReqTeamMember[];
 }
 export const useModifyTeamMembersMutation = () => {
   const toast = useToast();
 
   return useMutation({
-    mutationFn: ({teamId, payload}: ITeamMember) => ModifyTeamMembers(teamId, payload),
+    mutationFn: ({ teamId, payload }: ITeamMember) =>
+      ModifyTeamMembers(teamId, payload),
     onError: (error) => {
       console.error(error);
       toast({

--- a/idearly/src/hooks/useMyPageMutation.ts
+++ b/idearly/src/hooks/useMyPageMutation.ts
@@ -1,10 +1,10 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { useToast } from "@chakra-ui/react";
-import { useSetAtom } from "jotai";
+import { useAtom, useSetAtom } from "jotai";
 import { LoginStateAtom } from "../store/LoginPage.atoms";
-import { getCWaitTeam, getCurrentTeam, modifyUser, withdrawalUser } from "../services/apis/mypage.apis";
-import { userInfoAtom } from "../store";
+import { HandleInvite, getCWaitTeam, getCurrentTeam, modifyUser, withdrawalUser } from "../services/apis/mypage.apis";
+import { curTeamAtom, userInfoAtom, waitTeamAtom } from "../store";
 
 export const useWithdrawalMutation = () => {
   const setIsLoginState = useSetAtom(LoginStateAtom);
@@ -111,4 +111,35 @@ export const useGetWaitTeamQuery = () => {
     staleTime: 2 * 60 * 1000,
   });
   return { data, status, error };
+};
+
+interface IHandleInvite {
+  teamId: number,
+  isAccept: boolean,
+}
+export const useHandleInviteMutation = () => {
+  const [curTeam, setCurTeam] = useAtom(curTeamAtom);
+  const [waitTeam, setWaitTeam] = useAtom(waitTeamAtom);
+
+  return useMutation({
+    mutationFn: ({teamId, isAccept}: IHandleInvite) => HandleInvite(teamId, isAccept),
+    onError: (error) => {
+      console.error(error);
+    },
+    onSuccess: (data) => {
+      // 반환값을 보고, 이게 수락인지 거절인지 확인 후, 리스트에서 처리
+      // 반환값에 해당 TeamId도 같이 건내주면 좋겠다!
+      console.log('res: ', data);
+      // 수락이라면, 대기현황에서 삭제, 현재 팀으로 이동
+      // 거절이라면, 대기 현황에서 삭제
+      if (data.data) {
+        console.log('수락');
+        // setCurTeam()
+        // setWaitTeam()
+      } else {
+        console.log('거절');
+        // setWaitTeam()
+      }
+    },
+  });
 };

--- a/idearly/src/hooks/useMyPageMutation.ts
+++ b/idearly/src/hooks/useMyPageMutation.ts
@@ -1,9 +1,9 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { useToast } from "@chakra-ui/react";
 import { useSetAtom } from "jotai";
 import { LoginStateAtom } from "../store/LoginPage.atoms";
-import { modifyUser, withdrawalUser } from "../services/apis/mypage.apis";
+import { getCWaitTeam, getCurrentTeam, modifyUser, withdrawalUser } from "../services/apis/mypage.apis";
 import { userInfoAtom } from "../store";
 
 export const useWithdrawalMutation = () => {
@@ -85,4 +85,30 @@ export const useModifyUerMutation = () => {
       }, 1000);
     },
   });
+};
+
+export const useGetCurrentTeamQuery = () => {
+  const {
+    data,
+    status,
+    error,
+  } = useQuery({
+    queryKey: ["curTeam"],
+    queryFn: getCurrentTeam,
+    staleTime: 2 * 60 * 1000,
+  });
+  return { data, status, error };
+};
+
+export const useGetWaitTeamQuery = () => {
+  const {
+    data,
+    status,
+    error,
+  } = useQuery({
+    queryKey: ["waitTeam"],
+    queryFn: getCWaitTeam,
+    staleTime: 2 * 60 * 1000,
+  });
+  return { data, status, error };
 };

--- a/idearly/src/hooks/useMyPageMutation.ts
+++ b/idearly/src/hooks/useMyPageMutation.ts
@@ -26,11 +26,11 @@ export const useWithdrawalMutation = () => {
     onSuccess: (data) => {
       console.log(data);
       // 로그인 상태 업데이트
-      // setIsLoginState(false);
       setUserInfoState({
-        memberId: '',
-        email: '',
-        name: '',
+        authority: "",
+        memberId: "",
+        email: "",
+        name: "",
         isLogin: false,
       });
       toast({
@@ -66,8 +66,8 @@ export const useModifyUerMutation = () => {
       });
     },
     onSuccess: (data) => {
-      console.log('check: ', data);
-      console.log('check: ', data.data.data.name);
+      console.log("check: ", data);
+      console.log("check: ", data.data.data.name);
 
       setUserInfoState((prev) => ({ ...prev, name: data.data.data.name }));
 

--- a/idearly/src/hooks/useMyPageMutation.ts
+++ b/idearly/src/hooks/useMyPageMutation.ts
@@ -149,7 +149,7 @@ export const useTeamInfoQuery = (isClick: boolean, teamId: number) => {
     queryKey: ["teamInfo", teamId],
     queryFn:() => getTeamInfo(teamId),
     enabled: isClick,
-    // staleTime: 2 * 1000,
+    staleTime: 2 * 60 * 1000,
   });
   return { memberData, error, isLoading };
 }

--- a/idearly/src/hooks/useMyPageMutation.ts
+++ b/idearly/src/hooks/useMyPageMutation.ts
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useToast } from "@chakra-ui/react";
 
 import { useAtom, useSetAtom } from "jotai";
-import { HandleInvite, getCWaitTeam, getCurrentTeam, modifyUser, withdrawalUser } from "../services/apis/mypage.apis";
+import { handleInvite, getCWaitTeam, getCurrentTeam, modifyUser, withdrawalUser, getTeamInfo } from "../services/apis/mypage.apis";
 import { curTeamAtom, userInfoAtom, waitTeamAtom } from "../store";
 
 export const useWithdrawalMutation = () => {
@@ -116,12 +116,13 @@ interface IHandleInvite {
   teamId: number,
   isAccept: boolean,
 }
+
 export const useHandleInviteMutation = () => {
   const [curTeam, setCurTeam] = useAtom(curTeamAtom);
   const [waitTeam, setWaitTeam] = useAtom(waitTeamAtom);
 
   return useMutation({
-    mutationFn: ({teamId, isAccept}: IHandleInvite) => HandleInvite(teamId, isAccept),
+    mutationFn: ({teamId, isAccept}: IHandleInvite) => handleInvite(teamId, isAccept),
     onError: (error) => {
       console.error(error);
     },
@@ -142,3 +143,17 @@ export const useHandleInviteMutation = () => {
     },
   });
 };
+
+export const useTeamInfoQuery = (teamId: number) => {
+  const {
+    data,
+    status,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ["teamInfo", teamId],
+    queryFn:() => getTeamInfo(teamId),
+    staleTime: 2 * 1000,
+  });
+  return { data, status, error, refetch };
+}

--- a/idearly/src/hooks/useMyPageMutation.ts
+++ b/idearly/src/hooks/useMyPageMutation.ts
@@ -130,15 +130,22 @@ export const useHandleInviteMutation = () => {
       // 반환값을 보고, 이게 수락인지 거절인지 확인 후, 리스트에서 처리
       // 반환값에 해당 TeamId도 같이 건내주면 좋겠다!
       console.log('res: ', data);
+      console.log('res: ', data.data);
+      console.log('res: ', data.data.accept);
+
       // 수락이라면, 대기현황에서 삭제, 현재 팀으로 이동
       // 거절이라면, 대기 현황에서 삭제
-      if (data.data) {
+      if (data.data.accept) {
         console.log('수락');
-        // setCurTeam()
-        // setWaitTeam()
+        // teamId를 필터링해서 삭제.
+        console.log('teamID', data.data.teamId);
+        const accetedTeam = waitTeam.filter((team) => team.teamId == data.data.teamId)[0];
+        console.log("accetedTeam: ", accetedTeam);
+        setCurTeam((prev) => [...prev, accetedTeam])
+        setWaitTeam((prev) => prev.filter((team) => team.teamId == data.data.teamId));
       } else {
         console.log('거절');
-        // setWaitTeam()
+        setWaitTeam((prev) => prev.filter((team) => team.teamId == data.data.teamId));
       }
     },
   });

--- a/idearly/src/index.ts
+++ b/idearly/src/index.ts
@@ -1,3 +1,4 @@
+<<<<<<< Updated upstream
 // // src/index.ts
 // import { server } from './mocks/node'
 
@@ -6,3 +7,13 @@
 
 // // 애플리케이션 코드
 // // ...
+=======
+// [msw] src/index.ts
+import { server } from './mocks/node'
+
+// 모의 서버를 시작
+server.listen()
+
+// 애플리케이션 코드
+// ...
+>>>>>>> Stashed changes

--- a/idearly/src/index.ts
+++ b/idearly/src/index.ts
@@ -1,13 +1,3 @@
-<<<<<<< Updated upstream
-// // src/index.ts
-// import { server } from './mocks/node'
-
-// // 모의 서버를 시작
-// server.listen()
-
-// // 애플리케이션 코드
-// // ...
-=======
 // [msw] src/index.ts
 import { server } from './mocks/node'
 
@@ -16,4 +6,3 @@ server.listen()
 
 // 애플리케이션 코드
 // ...
->>>>>>> Stashed changes

--- a/idearly/src/layout/Header/Header.tsx
+++ b/idearly/src/layout/Header/Header.tsx
@@ -29,7 +29,6 @@ export const Header = () => {
       (response) => response,
       (error) => {
         if (error.response && error.response.status === 401) {
-          // setIsLoginState(false);
           setUserInfoState({
             authority: "",
             memberId: "",

--- a/idearly/src/layout/Header/Header.tsx
+++ b/idearly/src/layout/Header/Header.tsx
@@ -31,9 +31,10 @@ export const Header = () => {
         if (error.response && error.response.status === 401) {
           // setIsLoginState(false);
           setUserInfoState({
-            memberId: '',
-            email: '',
-            name: '',
+            authority: "",
+            memberId: "",
+            email: "",
+            name: "",
             isLogin: false,
           });
         }

--- a/idearly/src/main.tsx
+++ b/idearly/src/main.tsx
@@ -2,32 +2,6 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 
-<<<<<<< Updated upstream
-// async function enableMocking() {
-//   if (process.env.NODE_ENV !== 'development') {
-//     return
-//   }
- 
-//   const { worker } = await import('./mocks/browser')
- 
-//   // `worker.start()` returns a Promise that resolves
-//   // once the Service Worker is up and ready to intercept requests.
-//   return worker.start()
-// }
-
-// enableMocking().then(() => {
-//   ReactDOM.createRoot(document.getElementById("root")!).render(
-//     <React.StrictMode>
-//       <App />
-//     </React.StrictMode>
-//   );
-//   })
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
-=======
 async function enableMocking() {
   if (process.env.NODE_ENV !== 'development') {
     return
@@ -47,11 +21,8 @@ enableMocking().then(() => {
     </React.StrictMode>
   );
   })
-
-
 // ReactDOM.createRoot(document.getElementById("root")!).render(
 //   <React.StrictMode>
 //     <App />
 //   </React.StrictMode>
 // );
->>>>>>> Stashed changes

--- a/idearly/src/main.tsx
+++ b/idearly/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 
+<<<<<<< Updated upstream
 // async function enableMocking() {
 //   if (process.env.NODE_ENV !== 'development') {
 //     return
@@ -26,3 +27,31 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     <App />
   </React.StrictMode>
 );
+=======
+async function enableMocking() {
+  if (process.env.NODE_ENV !== 'development') {
+    return
+  }
+ 
+  const { worker } = await import('./mocks/browser')
+ 
+  // `worker.start()` returns a Promise that resolves
+  // once the Service Worker is up and ready to intercept requests.
+  return worker.start()
+}
+
+enableMocking().then(() => {
+  ReactDOM.createRoot(document.getElementById("root")!).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+  })
+
+
+// ReactDOM.createRoot(document.getElementById("root")!).render(
+//   <React.StrictMode>
+//     <App />
+//   </React.StrictMode>
+// );
+>>>>>>> Stashed changes

--- a/idearly/src/mocks/browser.ts
+++ b/idearly/src/mocks/browser.ts
@@ -1,15 +1,6 @@
-<<<<<<< Updated upstream
-// // src/mocks/browser.ts
-
-// import { setupWorker } from 'msw/browser'
-// import { handlers } from '../services/apis/mswApi/handlers'
- 
-// export const worker = setupWorker(...handlers)
-=======
 // [msw] src/mocks/browser.ts
 
 import { setupWorker } from 'msw/browser'
 import { handlers } from '../services/apis/mswApi/handlers'
  
 export const worker = setupWorker(...handlers)
->>>>>>> Stashed changes

--- a/idearly/src/mocks/browser.ts
+++ b/idearly/src/mocks/browser.ts
@@ -1,6 +1,15 @@
+<<<<<<< Updated upstream
 // // src/mocks/browser.ts
 
 // import { setupWorker } from 'msw/browser'
 // import { handlers } from '../services/apis/mswApi/handlers'
  
 // export const worker = setupWorker(...handlers)
+=======
+// [msw] src/mocks/browser.ts
+
+import { setupWorker } from 'msw/browser'
+import { handlers } from '../services/apis/mswApi/handlers'
+ 
+export const worker = setupWorker(...handlers)
+>>>>>>> Stashed changes

--- a/idearly/src/mocks/curCompetition.mocks.ts
+++ b/idearly/src/mocks/curCompetition.mocks.ts
@@ -1,6 +1,6 @@
-import { ICompetition } from "../pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.types";
+import { ITeam } from "../pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.types";
 
-export const curCompetition: ICompetition[] = [
+export const curCompetition: ITeam[] = [
   {
     teamId: 123,
     teamName: "snow",

--- a/idearly/src/mocks/node.ts
+++ b/idearly/src/mocks/node.ts
@@ -1,5 +1,13 @@
+<<<<<<< Updated upstream
 // // src/mocks/node.js
 // import { setupServer } from 'msw/node'
 // import { handlers } from '../services/apis/mswApi/handlers'
  
 // export const server = setupServer(...handlers)
+=======
+// [msw] src/mocks/node.js
+import { setupServer } from 'msw/node'
+import { handlers } from '../services/apis/mswApi/handlers'
+ 
+export const server = setupServer(...handlers)
+>>>>>>> Stashed changes

--- a/idearly/src/mocks/node.ts
+++ b/idearly/src/mocks/node.ts
@@ -1,13 +1,5 @@
-<<<<<<< Updated upstream
-// // src/mocks/node.js
-// import { setupServer } from 'msw/node'
-// import { handlers } from '../services/apis/mswApi/handlers'
- 
-// export const server = setupServer(...handlers)
-=======
 // [msw] src/mocks/node.js
 import { setupServer } from 'msw/node'
 import { handlers } from '../services/apis/mswApi/handlers'
  
 export const server = setupServer(...handlers)
->>>>>>> Stashed changes

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.tsx
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.tsx
@@ -12,25 +12,17 @@ export const MyPageCurrentTeam = () => {
   const { competitionName, teamName, leaderName, date, manage, choose} = MyPageCurrentTeamConfig;
   const { isOpen, onOpen, onClose } = useDisclosure();
 
-  const {data: curTeamData} = useGetCurrentTeamQuery();
-  const {data: waitTeamData} = useGetWaitTeamQuery();
-
+  const userInfo = useAtomValue(userInfoAtom);
   const [curTeam, setCurTeam] = useAtom(curTeamAtom);
   const [waitTeam, setWaitTeam] = useAtom(waitTeamAtom);
 
-  const [teamMembers, setTeamMembers] = useState<ITeamMember[]>([]);
-  
-  // curretMembers를 쪼개서 현재 맴버 / 수락 대기 중인 맴버 변수 만들기
-  console.log("teamMembers: ", teamMembers);
-  const currentMemberList: ITeamMember[] = teamMembers.filter(member => member.inviteStatus === "accept");
-  const inviteMemberList: ITeamMember[] = teamMembers.filter(member => member.inviteStatus === "invite");
-
   const [teamId, setTeamId] = useState(0);
   const [isClick, setIsClick] = useState(false);
+  const [teamMembers, setTeamMembers] = useState<ITeamMember[]>([]);
 
-  const {data: memberData, status, error, isInitialLoading} = useTeamInfoQuery(isClick, teamId);
-  
-  const userInfo = useAtomValue(userInfoAtom);
+  const {data: curTeamData} = useGetCurrentTeamQuery();
+  const {data: waitTeamData} = useGetWaitTeamQuery();
+  const { memberData, error, isLoading } = useTeamInfoQuery(isClick, teamId);
 
   // 참가 대회 소속팀 / 대기중인 초대 현황 정보 불러오기
   useEffect(() => {
@@ -45,20 +37,24 @@ export const MyPageCurrentTeam = () => {
     }
   }, [waitTeamData])
 
+  useEffect(() => {
+    if(memberData) {
+      setTeamMembers(memberData.data.teammates);
+    }
+  }, [memberData])
+
   const onClickTeamDetail = (teamId: number) => {
-    // 현재 팀 목록에서 팀 상세보기 클릭 시!
-    setIsClick(true);
     setTeamId(teamId);
-    // 모달창에 들어가는 정보 업데이트
-    setTeamMembers(memberData.data.teammates);
-  }
-  if (isInitialLoading) {
-    return <div>...Loadin1</div>;
+    setIsClick(true);
+    onOpen();
   }
 
-  if (status === "error") {
-    console.log(error);
-  }
+  if (isLoading) return <p>Loading...</p>;
+  if (error) return <p>Error: {error.message}</p>;
+  
+  // curretMembers를 쪼개서 현재 맴버 / 수락 대기 중인 맴버 변수 만들기
+  const currentMemberList: ITeamMember[] = teamMembers.filter((member:any) => member.inviteStatus === "accept");
+  const inviteMemberList: ITeamMember[] = teamMembers.filter((member:any) => member.inviteStatus === "invite");
 
   return (
     <S.SearchTeamWrapper>

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.tsx
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.tsx
@@ -40,9 +40,14 @@ export const MyPageCurrentTeam = () => {
   useEffect(() => {
     if(memberData) {
       setTeamMembers(memberData.data.teammates);
+      setCurrentMemberList(memberData.data.teammates.filter((member:any) => member.inviteStatus === "accept"));
+      setInviteMemberList(memberData.data.teammates.filter((member: any) => member.inviteStatus === "invite"));
     }
   }, [memberData])
 
+  const [currentMemberList, setCurrentMemberList] = useState<ITeamMember[]>(teamMembers.filter((member:any) => member.inviteStatus === "accept"))
+  const [inviteMemberList, setInviteMemberList] = useState<ITeamMember[]>(teamMembers.filter((member:any) => member.inviteStatus === "invite"));
+  
   const onClickTeamDetail = (teamId: number) => {
     setTeamId(teamId);
     setIsClick(true);
@@ -51,17 +56,13 @@ export const MyPageCurrentTeam = () => {
 
   if (isLoading) return <p>Loading...</p>;
   if (error) return <p>Error: {error.message}</p>;
-  
-  // curretMembers를 쪼개서 현재 맴버 / 수락 대기 중인 맴버 변수 만들기
-  const currentMemberList: ITeamMember[] = teamMembers.filter((member:any) => member.inviteStatus === "accept");
-  const inviteMemberList: ITeamMember[] = teamMembers.filter((member:any) => member.inviteStatus === "invite");
 
   return (
     <S.SearchTeamWrapper>
       {
         memberData?.data.leaderEmail === userInfo.email
-        ? <TeamModifyModal isOpen={isOpen} onClose={onClose} currentMemberList={currentMemberList} inviteMemberList={inviteMemberList} />
-        : <TeamDetailModal isOpen={isOpen} onClose={onClose} currentMemberList={currentMemberList} inviteMemberList={inviteMemberList} />
+        ? <TeamModifyModal isOpen={isOpen} onClose={onClose} currentMemberList={currentMemberList} setCurrentMemberList={setCurrentMemberList} inviteMemberList={inviteMemberList} setInviteMemberList={setInviteMemberList} />
+        : <TeamDetailModal isOpen={isOpen} onClose={onClose} currentMemberList={currentMemberList} inviteMemberList={inviteMemberList}  />
       }
       
       <S.SearchTeamTitle>현재 팀 조회</S.SearchTeamTitle>
@@ -80,7 +81,7 @@ export const MyPageCurrentTeam = () => {
           <Tbody>
             {
               curTeam.map((competition) => (
-                <CurrentTeamList key={competition.competitionId} competition={competition} onOpen={onOpen} onClickTeamDetail={onClickTeamDetail} />
+                <CurrentTeamList key={competition.competitionId} competition={competition} onClickTeamDetail={onClickTeamDetail} />
               ))
             }
           </Tbody>

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.tsx
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.tsx
@@ -47,7 +47,7 @@ export const MyPageCurrentTeam = () => {
 
   const [currentMemberList, setCurrentMemberList] = useState<ITeamMember[]>(teamMembers.filter((member:any) => member.inviteStatus === "accept"))
   const [inviteMemberList, setInviteMemberList] = useState<ITeamMember[]>(teamMembers.filter((member:any) => member.inviteStatus === "invite"));
-  
+
   const onClickTeamDetail = (teamId: number) => {
     setTeamId(teamId);
     setIsClick(true);
@@ -61,7 +61,7 @@ export const MyPageCurrentTeam = () => {
     <S.SearchTeamWrapper>
       {
         memberData?.data.leaderEmail === userInfo.email
-        ? <TeamModifyModal isOpen={isOpen} onClose={onClose} currentMemberList={currentMemberList} setCurrentMemberList={setCurrentMemberList} inviteMemberList={inviteMemberList} setInviteMemberList={setInviteMemberList} />
+        ? <TeamModifyModal isOpen={isOpen} onClose={onClose} currentMemberList={currentMemberList} setCurrentMemberList={setCurrentMemberList} inviteMemberList={inviteMemberList} setInviteMemberList={setInviteMemberList} teamId={teamId} />
         : <TeamDetailModal isOpen={isOpen} onClose={onClose} currentMemberList={currentMemberList} inviteMemberList={inviteMemberList}  />
       }
       

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.tsx
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.tsx
@@ -19,12 +19,12 @@ export const MyPageCurrentTeam = () => {
   const [waitTeam, setWaitTeam] = useAtom(waitTeamAtom);
 
   const [teamMembers, setTeamMembers] = useState<ITeamMember[]>([]);
+
   // curretMembers를 쪼개서 현재 맴버 / 수락 대기 중인 맴버 변수 만들기
-  console.log(teamMembers);
+  console.log("teamMembers: ", teamMembers);
   const currentMemberList: ITeamMember[] = teamMembers.filter(member => member.inviteStatus === "accept");
   const inviteMemberList: ITeamMember[] = teamMembers.filter(member => member.inviteStatus === "invite");
 
-  // teamID도 따로 관리를 해줘야하나?
   const [teamId, setTeamId] = useState(0);
   const {data: memberData, status, error, refetch} = useTeamInfoQuery(teamId);
 
@@ -49,7 +49,7 @@ export const MyPageCurrentTeam = () => {
     if (status === "error") {
       console.log(error);
     }
-    // 모달창에 들어가는 정보도 업데이트 필요!
+    // 모달창에 들어가는 정보 업데이트
     setTeamMembers(memberData.data.teammates);
   }
   return (

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.tsx
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.tsx
@@ -1,36 +1,41 @@
 import { Table, Tbody, Th, Thead, Tr, useDisclosure } from "@chakra-ui/react";
 import * as S from "./MyPageCurrentTeam.styles";
-import { curCompetition, TeamMembers } from "../../../../mocks/curCompetition.mocks";
+import { TeamMembers } from "../../../../mocks/curCompetition.mocks";
 import { CurrentTeamList, TeamModifyModal, WaitingTeamList } from "./components";
 import { MyPageCurrentTeamConfig } from "../../../../constants/MyPage.constants";
-import type { ICompetition, ITeamMember } from "./MyPageCurrentTeam.types";
-import { useEffect, useState } from "react";
+import type { ITeamMember } from "./MyPageCurrentTeam.types";
+import { useEffect } from "react";
 import { useGetCurrentTeamQuery, useGetWaitTeamQuery } from "../../../../hooks/useMyPageMutation";
+import { useAtom } from "jotai";
+import { curTeamAtom, waitTeamAtom } from "../../../../store";
 
 export const MyPageCurrentTeam = () => {
   const { competitionName, teamName, leaderName, date, manage, choose} = MyPageCurrentTeamConfig;
   const { isOpen, onOpen, onClose } = useDisclosure();
 
+  const {data: curTeamData} = useGetCurrentTeamQuery();
+  const {data: waitTeamData} = useGetWaitTeamQuery();
+
+  const [curTeam, setCurTeam] = useAtom(curTeamAtom);
+
+  const [waitTeam, setWaitTeam] = useAtom(waitTeamAtom);
+
   // curretMembers를 쪼개서 현재 맴버 / 수락 대기 중인 맴버 변수 만들기
   const currentMemberList: ITeamMember[] = TeamMembers.teammates.filter(member => member.inviteStatus === "accept");
   const inviteMemberList: ITeamMember[] = TeamMembers.teammates.filter(member => member.inviteStatus === "invite");
 
-  const {data: curTeamData} = useGetCurrentTeamQuery();
-  const {data: waitTeamData} = useGetWaitTeamQuery();
 
-  const [curCompetition, setCurCompetition] = useState<ICompetition[]>([]);
-  const [waitCompetition, setWaitCompetition] = useState<ICompetition[]>([]);
 
   // 참가 대회 소속팀 / 대기중인 초대 현황 정보 불러오기
   useEffect(() => {
     if(curTeamData) {
-      setCurCompetition(curTeamData.data.teams);
+      setCurTeam(curTeamData.data.teams);
     }
   }, [curTeamData])
 
   useEffect(() => {
     if(waitTeamData) {
-      setWaitCompetition(waitTeamData.data.teams);
+      setWaitTeam(waitTeamData.data.teams);
     }
   }, [waitTeamData])
 
@@ -54,7 +59,7 @@ export const MyPageCurrentTeam = () => {
           </Thead>
           <Tbody>
             {
-              curCompetition.map((competition) => (
+              curTeam.map((competition) => (
                 <CurrentTeamList key={competition.competitionId} competition={competition} onOpen={onOpen} />
               ))
             }
@@ -76,7 +81,7 @@ export const MyPageCurrentTeam = () => {
           </Thead>
           <Tbody>
             {
-              waitCompetition.map((competition) => (
+              waitTeam.map((competition) => (
                 <WaitingTeamList key={competition.competitionId} competition={competition} />
               ))
             }

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.tsx
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.tsx
@@ -3,7 +3,9 @@ import * as S from "./MyPageCurrentTeam.styles";
 import { curCompetition, TeamMembers } from "../../../../mocks/curCompetition.mocks";
 import { CurrentTeamList, TeamModifyModal, WaitingTeamList } from "./components";
 import { MyPageCurrentTeamConfig } from "../../../../constants/MyPage.constants";
-import type { ITeamMember } from "./MyPageCurrentTeam.types";
+import type { ICompetition, ITeamMember } from "./MyPageCurrentTeam.types";
+import { useEffect, useState } from "react";
+import { useGetCurrentTeamQuery, useGetWaitTeamQuery } from "../../../../hooks/useMyPageMutation";
 
 export const MyPageCurrentTeam = () => {
   const { competitionName, teamName, leaderName, date, manage, choose} = MyPageCurrentTeamConfig;
@@ -12,6 +14,25 @@ export const MyPageCurrentTeam = () => {
   // curretMembers를 쪼개서 현재 맴버 / 수락 대기 중인 맴버 변수 만들기
   const currentMemberList: ITeamMember[] = TeamMembers.teammates.filter(member => member.inviteStatus === "accept");
   const inviteMemberList: ITeamMember[] = TeamMembers.teammates.filter(member => member.inviteStatus === "invite");
+
+  const {data: curTeamData} = useGetCurrentTeamQuery();
+  const {data: waitTeamData} = useGetWaitTeamQuery();
+
+  const [curCompetition, setCurCompetition] = useState<ICompetition[]>([]);
+  const [waitCompetition, setWaitCompetition] = useState<ICompetition[]>([]);
+
+  // 참가 대회 소속팀 / 대기중인 초대 현황 정보 불러오기
+  useEffect(() => {
+    if(curTeamData) {
+      setCurCompetition(curTeamData.data.teams);
+    }
+  }, [curTeamData])
+
+  useEffect(() => {
+    if(waitTeamData) {
+      setWaitCompetition(waitTeamData.data.teams);
+    }
+  }, [waitTeamData])
 
   return (
     <S.SearchTeamWrapper>
@@ -55,7 +76,7 @@ export const MyPageCurrentTeam = () => {
           </Thead>
           <Tbody>
             {
-              curCompetition.map((competition) => (
+              waitCompetition.map((competition) => (
                 <WaitingTeamList key={competition.competitionId} competition={competition} />
               ))
             }

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.types.ts
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.types.ts
@@ -11,8 +11,11 @@ export interface ITeam {
 
 export interface ICompetitionProp {
   competition: ITeam;
-  onOpen?: () => void;
-  onClickTeamDetail?: (teamId: number) => void;
+  onClickTeamDetail: (teamId: number) => void;
+}
+
+export interface IWaitingCompetitionProp {
+  competition: ITeam;
 }
 
 export interface ITeamMember {
@@ -21,9 +24,24 @@ export interface ITeamMember {
   inviteStatus?: string,
 }
 
-export interface ITeamlModal {
+export interface IModifyTeamlModal {
   isOpen: boolean;
   onClose: () => void;
   currentMemberList: ITeamMember[];
   inviteMemberList: ITeamMember[];
+  setCurrentMemberList: React.Dispatch<React.SetStateAction<ITeamMember[]>>;
+  setInviteMemberList: React.Dispatch<React.SetStateAction<ITeamMember[]>>;
+}
+
+export interface IDetailTeamlModal {
+  isOpen: boolean;
+  onClose: () => void;
+  currentMemberList: ITeamMember[];
+  inviteMemberList: ITeamMember[];
+}
+
+export interface ITeamModal {
+  isOpen: boolean;
+  onClose: () => void;
+  teamMembers: ITeamMember[];
 }

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.types.ts
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.types.ts
@@ -31,6 +31,7 @@ export interface IModifyTeamlModal {
   inviteMemberList: ITeamMember[];
   setCurrentMemberList: React.Dispatch<React.SetStateAction<ITeamMember[]>>;
   setInviteMemberList: React.Dispatch<React.SetStateAction<ITeamMember[]>>;
+  teamId: number;
 }
 
 export interface IDetailTeamlModal {

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.types.ts
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.types.ts
@@ -12,6 +12,7 @@ export interface ITeam {
 export interface ICompetitionProp {
   competition: ITeam;
   onOpen?: () => void;
+  onClickTeamDetail?: (teamId: number) => void;
 }
 
 export interface ITeamMember {

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.types.ts
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.types.ts
@@ -1,4 +1,4 @@
-export interface ICompetition {
+export interface ITeam {
   teamId: number,
   teamName: string,
   competitionId: number,
@@ -10,7 +10,7 @@ export interface ICompetition {
 }
 
 export interface ICompetitionProp {
-  competition: ICompetition;
+  competition: ITeam;
   onOpen?: () => void;
 }
 

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/CurrentTeamList/CurrentTeamList.tsx
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/CurrentTeamList/CurrentTeamList.tsx
@@ -8,7 +8,6 @@ export const CurrentTeamList = ({competition, onOpen, onClickTeamDetail}: PropsW
   
   const handleClick = () => {
     onClickTeamDetail!(teamId);
-    onOpen!();
   }
   return (
     <Tr key={competitionId}>

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/CurrentTeamList/CurrentTeamList.tsx
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/CurrentTeamList/CurrentTeamList.tsx
@@ -3,9 +3,13 @@ import { PropsWithChildren } from "react"
 import { dateChange } from "../../../../../../utils/dateChange"
 import { ICompetitionProp } from "../../MyPageCurrentTeam.types"
 
-export const CurrentTeamList = ({competition, onOpen}: PropsWithChildren<ICompetitionProp>) => {
-  const {competitionId, competitionTitle, teamName, leaderName, startDateTime} = competition;
+export const CurrentTeamList = ({competition, onOpen, onClickTeamDetail}: PropsWithChildren<ICompetitionProp>) => {
+  const {teamId, competitionId, competitionTitle, teamName, leaderName, startDateTime} = competition;
   
+  const handleClick = () => {
+    onClickTeamDetail!(teamId);
+    onOpen!();
+  }
   return (
     <Tr key={competitionId}>
       <Td>{competitionTitle}</Td>
@@ -13,7 +17,7 @@ export const CurrentTeamList = ({competition, onOpen}: PropsWithChildren<ICompet
       <Td>{leaderName}</Td>
       <Td>{dateChange({ date: startDateTime })}</Td>
       <Td>
-        <Button onClick={onOpen}>상세 보기</Button>  
+        <Button onClick={handleClick}>상세 보기</Button>  
       </Td>
     </Tr>
   )

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/CurrentTeamList/CurrentTeamList.tsx
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/CurrentTeamList/CurrentTeamList.tsx
@@ -3,11 +3,11 @@ import { PropsWithChildren } from "react"
 import { dateChange } from "../../../../../../utils/dateChange"
 import { ICompetitionProp } from "../../MyPageCurrentTeam.types"
 
-export const CurrentTeamList = ({competition, onOpen, onClickTeamDetail}: PropsWithChildren<ICompetitionProp>) => {
+export const CurrentTeamList = ({competition, onClickTeamDetail}: PropsWithChildren<ICompetitionProp>) => {
   const {teamId, competitionId, competitionTitle, teamName, leaderName, startDateTime} = competition;
   
   const handleClick = () => {
-    onClickTeamDetail!(teamId);
+    onClickTeamDetail(teamId);
   }
   return (
     <Tr key={competitionId}>

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/TeamDetailModal/TeamDetailModal.tsx
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/TeamDetailModal/TeamDetailModal.tsx
@@ -1,9 +1,9 @@
 import { Button, Modal, ModalBody, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalOverlay } from "@chakra-ui/react"
 import * as S from "./TeamDetailModal.styles";
 import { PropsWithChildren } from "react";
-import { ITeamlModal } from "../../MyPageCurrentTeam.types";
+import { IDetailTeamlModal } from "../../MyPageCurrentTeam.types";
 
-export const TeamDetailModal = ({ isOpen, onClose, currentMemberList, inviteMemberList}: PropsWithChildren<ITeamlModal>) => {
+export const TeamDetailModal = ({ isOpen, onClose, currentMemberList, inviteMemberList}: PropsWithChildren<IDetailTeamlModal>) => {
   const MAXMEMBER = 2;
   console.log('In detail modal, currentMemberList: ', currentMemberList, 'inviteMemberList:', inviteMemberList);
   return (

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/TeamDetailModal/TeamDetailModal.tsx
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/TeamDetailModal/TeamDetailModal.tsx
@@ -5,7 +5,7 @@ import { ITeamlModal } from "../../MyPageCurrentTeam.types";
 
 export const TeamDetailModal = ({ isOpen, onClose, currentMemberList, inviteMemberList}: PropsWithChildren<ITeamlModal>) => {
   const MAXMEMBER = 2;
-  
+  console.log('In detail modal, currentMemberList: ', currentMemberList, 'inviteMemberList:', inviteMemberList);
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
@@ -13,16 +13,16 @@ export const TeamDetailModal = ({ isOpen, onClose, currentMemberList, inviteMemb
           <ModalHeader>팀 상세 정보</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
-            <S.ModalSubTitle>초대 수락한 맴버({currentMemberList.length}/{MAXMEMBER+1})</S.ModalSubTitle>
+            <S.ModalSubTitle>초대 수락한 맴버({currentMemberList?.length}/{MAXMEMBER+1})</S.ModalSubTitle>
 
             {
-              currentMemberList.map(member => (
+              currentMemberList?.map(member => (
                 <S.ModalContent key={member.email}>{member.name}({member.email})</S.ModalContent>
               ))
             }
-            <S.ModalSubTitle>수락 대기중인 맴버({inviteMemberList.length}/{MAXMEMBER+1})</S.ModalSubTitle>
+            <S.ModalSubTitle>수락 대기중인 맴버({inviteMemberList?.length}/{MAXMEMBER+1})</S.ModalSubTitle>
             {
-              inviteMemberList.map(member => (
+              inviteMemberList?.map(member => (
                 <S.ModalContent key={member.email}>{member.name}({member.email})</S.ModalContent>
               ))
             }

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/TeamDetailModal/TeamDetailModal.tsx
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/TeamDetailModal/TeamDetailModal.tsx
@@ -5,7 +5,7 @@ import { ITeamlModal } from "../../MyPageCurrentTeam.types";
 
 export const TeamDetailModal = ({ isOpen, onClose, currentMemberList, inviteMemberList}: PropsWithChildren<ITeamlModal>) => {
   const MAXMEMBER = 2;
-
+  
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/TeamDetailModal/TeamDetailModal.tsx
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/TeamDetailModal/TeamDetailModal.tsx
@@ -5,6 +5,7 @@ import { ITeamlModal } from "../../MyPageCurrentTeam.types";
 
 export const TeamDetailModal = ({ isOpen, onClose, currentMemberList, inviteMemberList}: PropsWithChildren<ITeamlModal>) => {
   const MAXMEMBER = 2;
+
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/TeamModifyModal/TeamModifyModal.tsx
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/TeamModifyModal/TeamModifyModal.tsx
@@ -1,28 +1,27 @@
 import { Button, Modal, ModalBody, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalOverlay} from "@chakra-ui/react"
 import { PropsWithChildren, useState } from "react";
-import { ITeamMember, ITeamlModal } from "../../MyPageCurrentTeam.types";
+import { IModifyTeamlModal, ITeamMember, ITeamModal } from "../../MyPageCurrentTeam.types";
 import { AddTeamMembers } from "../../../../../../components/AddTeamMembers/AddTeamMembers";
 import { IUserType } from "../../../../../TeamMatchingPage/TeamMatchingPage.types";
 import * as S from "./TeamModifyModal.styles";
 import { CloseIcon } from "@chakra-ui/icons";
 
-export const TeamModifyModal = ({ isOpen, onClose, currentMemberList, inviteMemberList}: PropsWithChildren<ITeamlModal>) => {
-  const [addedMembers, setAddedMembers] = useState<ITeamMember[]>(currentMemberList);
-  const MAX_MEMBER = 2;
-  const isErrorCount = addedMembers?.length !== MAX_MEMBER; // 만약 팀 생성을 눌렀을 때, 인원이 다 안모였다면 활성화
+export const TeamModifyModal = ({ isOpen, onClose, currentMemberList, inviteMemberList, setCurrentMemberList, setInviteMemberList}: PropsWithChildren<IModifyTeamlModal>) => {
 
-  const [addedInviteMembers, setAddedInviteMembers] = useState(inviteMemberList);
-  
+  const MAX_MEMBER = 2;
+  const isErrorCount = currentMemberList?.length !== MAX_MEMBER; // 만약 팀 생성을 눌렀을 때, 인원이 다 안모였다면 활성화
+
   console.log('In modify modal, cur:', currentMemberList, 'invite:', inviteMemberList);
+
   const handleDropoutMember = (email: string) => {
     // 해당 email을 가지고 있는 유저 삭제
-    setAddedInviteMembers(addedInviteMembers.filter(member => member.email !== email));
+    setInviteMemberList(inviteMemberList.filter(member => member.email !== email));
 
     // 강퇴 api 
   }
 
   const handleDelete = (email: string) => {
-    setAddedMembers(addedMembers.filter((user) => user.email !== email));
+    setCurrentMemberList(currentMemberList.filter((user) => user.email !== email));
   }
 
   const handleSubmit = () => {
@@ -37,12 +36,12 @@ export const TeamModifyModal = ({ isOpen, onClose, currentMemberList, inviteMemb
           <ModalHeader>팀 상세 정보</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
-            <S.ModalSubTitle>총 맴버 수({addedMembers?.length+inviteMemberList?.length + 1}/{MAX_MEMBER+1})</S.ModalSubTitle>
-            <AddTeamMembers setAddedMembers={setAddedMembers} isErrorCount={isErrorCount} />
+            <S.ModalSubTitle>총 맴버 수({currentMemberList?.length+inviteMemberList?.length + 1}/{MAX_MEMBER+1})</S.ModalSubTitle>
+            <AddTeamMembers setAddedMembers={setCurrentMemberList} isErrorCount={isErrorCount} />
             <S.ModalSubTitle>수락 대기중인 맴버</S.ModalSubTitle>
 
             <S.MemberListWrapper>
-              {addedMembers?.map((user: IUserType) => (
+              {currentMemberList?.map((user: IUserType) => (
                 <S.MemberWrapper key={user.email}>
                   <S.ModalContent key={user.email}>{user.name}({user.email})</S.ModalContent>
                   <S.IconWrapper as={CloseIcon} onClick={() => handleDelete(user.email)} />
@@ -57,7 +56,7 @@ export const TeamModifyModal = ({ isOpen, onClose, currentMemberList, inviteMemb
               </S.ModalContent>
             <S.MemberListWrapper>
             {
-              addedInviteMembers?.map(member => (
+              inviteMemberList?.map(member => (
                 <S.MemberWrapper key={member.email}>
                   <S.ModalContent key={member.email}>{member.name}({member.email})</S.ModalContent>
                   <S.Dropout onClick={() => handleDropoutMember(member.email)}>강퇴</S.Dropout>

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/TeamModifyModal/TeamModifyModal.tsx
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/TeamModifyModal/TeamModifyModal.tsx
@@ -12,32 +12,28 @@ import { userInfoAtom } from "../../../../../../store";
 
 export const TeamModifyModal = ({ isOpen, onClose, currentMemberList, inviteMemberList, setCurrentMemberList, setInviteMemberList, teamId}: PropsWithChildren<IModifyTeamlModal>) => {
 
-  const MAX_MEMBER = 2;
-  const isErrorCount = currentMemberList?.length !== MAX_MEMBER; // 만약 팀 생성을 눌렀을 때, 인원이 다 안모였다면 활성화
-  const { mutate } = useModifyTeamMembersMutation();
-  console.log('In modify modal, cur:', currentMemberList, 'invite:', inviteMemberList);
+  const MAX_MEMBER = 3;
   const userInfo = useAtomValue(userInfoAtom);
+  const { mutate } = useModifyTeamMembersMutation();
+  const totalMemberNum = currentMemberList?.length + inviteMemberList?.length;
+  const isFullMember = totalMemberNum !== MAX_MEMBER; // 만약 팀 생성을 눌렀을 때, 인원이 다 안모였다면 활성화
 
   const handleDropoutMember = (email: string) => {
-    // 해당 email을 가지고 있는 유저 삭제
-    setInviteMemberList(inviteMemberList.filter(member => member.email !== email));
+    setCurrentMemberList(currentMemberList.filter(member => member.email !== email));
   }
 
   const handleDelete = (email: string) => {
-    setCurrentMemberList(currentMemberList.filter((user) => user.email !== email));
+    console.log(email);
+    setInviteMemberList(inviteMemberList.filter((user) => user.email !== email));
   }
 
   const handleSubmit = () => {
-    onClose();
-
     const temp: ITeamMember[] = [...inviteMemberList, ...currentMemberList]
-
     const payload: IReqTeamMember[] = temp.map((member) => ({ name: member.name, email: member.email })).filter(member => member.email !== userInfo.email);
-
-    console.log(payload);
-    
     mutate({teamId, payload});
+    onClose();
   }
+  console.log('In modify modal, currentMemberList: ', currentMemberList, 'inviteMemberList:', inviteMemberList);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
@@ -46,27 +42,29 @@ export const TeamModifyModal = ({ isOpen, onClose, currentMemberList, inviteMemb
           <ModalHeader>팀 상세 정보</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
-            <S.ModalSubTitle>총 맴버 수({currentMemberList?.length+inviteMemberList?.length + 1}/{MAX_MEMBER+1})</S.ModalSubTitle>
-            <AddTeamMembers setAddedMembers={setCurrentMemberList} isErrorCount={isErrorCount} />
+            <S.ModalSubTitle>총 맴버 수({totalMemberNum}/{MAX_MEMBER})</S.ModalSubTitle>
+            <AddTeamMembers setAddedMembers={setInviteMemberList} isErrorCount={isFullMember} />
             <S.ModalSubTitle>수락 대기중인 맴버</S.ModalSubTitle>
 
             <S.MemberListWrapper>
-              {currentMemberList?.map((user: IUserType) => (
-                <S.MemberWrapper key={user.email}>
-                  <S.ModalContent key={user.email}>{user.name}({user.email})</S.ModalContent>
-                  <S.IconWrapper as={CloseIcon} onClick={() => handleDelete(user.email)} />
-                </S.MemberWrapper>
-              ))}
+              {
+                inviteMemberList?.map((user: IUserType) => (
+                  <S.MemberWrapper key={user.email}>
+                    <S.ModalContent key={user.email}>{user.name}({user.email})</S.ModalContent>
+                    <S.IconWrapper as={CloseIcon} onClick={() => handleDelete(user.email)} />
+                  </S.MemberWrapper>
+                ))
+              }
             </S.MemberListWrapper>
             
               
-            <S.ModalSubTitle>수락완료한 맴버</S.ModalSubTitle>
-            <S.ModalContent>
+            <S.ModalSubTitle>맴버 리스트</S.ModalSubTitle>
+              <S.ModalContent>
                 나
               </S.ModalContent>
             <S.MemberListWrapper>
             {
-              inviteMemberList?.map(member => (
+              currentMemberList?.filter(member => member.email !== userInfo.email).map(member => (
                 <S.MemberWrapper key={member.email}>
                   <S.ModalContent key={member.email}>{member.name}({member.email})</S.ModalContent>
                   <S.Dropout onClick={() => handleDropoutMember(member.email)}>강퇴</S.Dropout>
@@ -76,7 +74,7 @@ export const TeamModifyModal = ({ isOpen, onClose, currentMemberList, inviteMemb
             </S.MemberListWrapper>
           </ModalBody>
           <ModalFooter>
-            <Button colorScheme='blue' onClick={handleSubmit} >
+            <Button colorScheme='blue' onClick={handleSubmit} isDisabled={isFullMember}>
               수정
             </Button>
           </ModalFooter>

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/TeamModifyModal/TeamModifyModal.tsx
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/TeamModifyModal/TeamModifyModal.tsx
@@ -9,10 +9,11 @@ import { CloseIcon } from "@chakra-ui/icons";
 export const TeamModifyModal = ({ isOpen, onClose, currentMemberList, inviteMemberList}: PropsWithChildren<ITeamlModal>) => {
   const [addedMembers, setAddedMembers] = useState<ITeamMember[]>(currentMemberList);
   const MAX_MEMBER = 2;
-  const isErrorCount = addedMembers.length !== MAX_MEMBER; // 만약 팀 생성을 눌렀을 때, 인원이 다 안모였다면 활성화
+  const isErrorCount = addedMembers?.length !== MAX_MEMBER; // 만약 팀 생성을 눌렀을 때, 인원이 다 안모였다면 활성화
 
   const [addedInviteMembers, setAddedInviteMembers] = useState(inviteMemberList);
   
+  console.log('In modify modal, cur:', currentMemberList, 'invite:', inviteMemberList);
   const handleDropoutMember = (email: string) => {
     // 해당 email을 가지고 있는 유저 삭제
     setAddedInviteMembers(addedInviteMembers.filter(member => member.email !== email));
@@ -36,12 +37,12 @@ export const TeamModifyModal = ({ isOpen, onClose, currentMemberList, inviteMemb
           <ModalHeader>팀 상세 정보</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
-            <S.ModalSubTitle>총 맴버 수({addedMembers.length+inviteMemberList.length + 1}/{MAX_MEMBER+1})</S.ModalSubTitle>
+            <S.ModalSubTitle>총 맴버 수({addedMembers?.length+inviteMemberList?.length + 1}/{MAX_MEMBER+1})</S.ModalSubTitle>
             <AddTeamMembers setAddedMembers={setAddedMembers} isErrorCount={isErrorCount} />
             <S.ModalSubTitle>수락 대기중인 맴버</S.ModalSubTitle>
 
             <S.MemberListWrapper>
-              {addedMembers.map((user: IUserType) => (
+              {addedMembers?.map((user: IUserType) => (
                 <S.MemberWrapper key={user.email}>
                   <S.ModalContent key={user.email}>{user.name}({user.email})</S.ModalContent>
                   <S.IconWrapper as={CloseIcon} onClick={() => handleDelete(user.email)} />
@@ -56,7 +57,7 @@ export const TeamModifyModal = ({ isOpen, onClose, currentMemberList, inviteMemb
               </S.ModalContent>
             <S.MemberListWrapper>
             {
-              addedInviteMembers.map(member => (
+              addedInviteMembers?.map(member => (
                 <S.MemberWrapper key={member.email}>
                   <S.ModalContent key={member.email}>{member.name}({member.email})</S.ModalContent>
                   <S.Dropout onClick={() => handleDropoutMember(member.email)}>강퇴</S.Dropout>

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/TeamModifyModal/TeamModifyModal.tsx
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/TeamModifyModal/TeamModifyModal.tsx
@@ -5,19 +5,22 @@ import { AddTeamMembers } from "../../../../../../components/AddTeamMembers/AddT
 import { IUserType } from "../../../../../TeamMatchingPage/TeamMatchingPage.types";
 import * as S from "./TeamModifyModal.styles";
 import { CloseIcon } from "@chakra-ui/icons";
+import { useModifyTeamMembersMutation } from "../../../../../../hooks/useMyPageMutation";
+import { IReqTeamMember } from "../../../../../../types";
+import { useAtomValue } from "jotai";
+import { userInfoAtom } from "../../../../../../store";
 
-export const TeamModifyModal = ({ isOpen, onClose, currentMemberList, inviteMemberList, setCurrentMemberList, setInviteMemberList}: PropsWithChildren<IModifyTeamlModal>) => {
+export const TeamModifyModal = ({ isOpen, onClose, currentMemberList, inviteMemberList, setCurrentMemberList, setInviteMemberList, teamId}: PropsWithChildren<IModifyTeamlModal>) => {
 
   const MAX_MEMBER = 2;
   const isErrorCount = currentMemberList?.length !== MAX_MEMBER; // 만약 팀 생성을 눌렀을 때, 인원이 다 안모였다면 활성화
-
+  const { mutate } = useModifyTeamMembersMutation();
   console.log('In modify modal, cur:', currentMemberList, 'invite:', inviteMemberList);
+  const userInfo = useAtomValue(userInfoAtom);
 
   const handleDropoutMember = (email: string) => {
     // 해당 email을 가지고 있는 유저 삭제
     setInviteMemberList(inviteMemberList.filter(member => member.email !== email));
-
-    // 강퇴 api 
   }
 
   const handleDelete = (email: string) => {
@@ -26,7 +29,14 @@ export const TeamModifyModal = ({ isOpen, onClose, currentMemberList, inviteMemb
 
   const handleSubmit = () => {
     onClose();
-    // 맴버 추가 리스트 백엔드로 보내기
+
+    const temp: ITeamMember[] = [...inviteMemberList, ...currentMemberList]
+
+    const payload: IReqTeamMember[] = temp.map((member) => ({ name: member.name, email: member.email })).filter(member => member.email !== userInfo.email);
+
+    console.log(payload);
+    
+    mutate({teamId, payload});
   }
 
   return (

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/WaitingTeamList/WaitingTeamList.tsx
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/WaitingTeamList/WaitingTeamList.tsx
@@ -1,11 +1,11 @@
 import { Button, Td, Tr } from "@chakra-ui/react"
 import { PropsWithChildren } from "react"
-import { ICompetitionProp } from "../../MyPageCurrentTeam.types"
+import { IWaitingCompetitionProp } from "../../MyPageCurrentTeam.types"
 import { dateChange } from "../../../../../../utils/dateChange"
 import * as S from "./WaitingTeamList.styles";
 import { useHandleInviteMutation } from "../../../../../../hooks/useMyPageMutation";
 
-export const WaitingTeamList = ({competition}: PropsWithChildren<ICompetitionProp>) => {
+export const WaitingTeamList = ({competition}: PropsWithChildren<IWaitingCompetitionProp>) => {
   const {teamId, competitionId, competitionTitle, teamName, leaderName, startDateTime} = competition;
 
   const {mutate} = useHandleInviteMutation();

--- a/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/WaitingTeamList/WaitingTeamList.tsx
+++ b/idearly/src/pages/MyPage/components/MyPgaeCurrentTeam/components/WaitingTeamList/WaitingTeamList.tsx
@@ -3,10 +3,19 @@ import { PropsWithChildren } from "react"
 import { ICompetitionProp } from "../../MyPageCurrentTeam.types"
 import { dateChange } from "../../../../../../utils/dateChange"
 import * as S from "./WaitingTeamList.styles";
+import { useHandleInviteMutation } from "../../../../../../hooks/useMyPageMutation";
 
 export const WaitingTeamList = ({competition}: PropsWithChildren<ICompetitionProp>) => {
-  const {competitionId, competitionTitle, teamName, leaderName, startDateTime} = competition;
+  const {teamId, competitionId, competitionTitle, teamName, leaderName, startDateTime} = competition;
 
+  const {mutate} = useHandleInviteMutation();
+  const handleSuccess = () => {
+    mutate({teamId, isAccept: true});
+  }
+
+  const handleReject = () => {
+    mutate({teamId, isAccept: false});
+  }
   return (
     <Tr key={competitionId}>
       <Td>{competitionTitle}</Td>
@@ -15,8 +24,8 @@ export const WaitingTeamList = ({competition}: PropsWithChildren<ICompetitionPro
       <Td>{dateChange({ date: startDateTime })}</Td>
       <Td>
         <S.ButtonGroup>
-          <Button>수락</Button>  
-          <Button>거절</Button>  
+          <Button onClick={handleSuccess}>수락</Button>  
+          <Button onClick={handleReject}>거절</Button>  
         </S.ButtonGroup>
       </Td>
     </Tr>

--- a/idearly/src/routes/AdminProtectedRoute.tsx
+++ b/idearly/src/routes/AdminProtectedRoute.tsx
@@ -1,0 +1,18 @@
+import { useAtomValue } from "jotai";
+import { Outlet, useNavigate } from "react-router-dom";
+import { userInfoAtom } from "../store";
+import { useEffect } from "react";
+
+export const AdminProtectedRoute = () => {
+  const navigate = useNavigate();
+  const userInfo = useAtomValue(userInfoAtom);
+
+  useEffect(() => {
+    // 현재 로그인 상태라면 홈 페이지로 리다이렉트
+    if (userInfo.authority === "USER" && !userInfo.isLogin) {
+      navigate("/", { replace: true });
+    }
+  }, [userInfo.authority, navigate]);
+
+  return <Outlet />;
+};

--- a/idearly/src/routes/routing.tsx
+++ b/idearly/src/routes/routing.tsx
@@ -15,6 +15,7 @@ import {
 } from "../pages";
 import ProtectedRoute from "./ProtectedRoute";
 import { IsLoginProtectedRoute } from "./IsLoginProtectedRoute";
+import { AdminProtectedRoute } from "./AdminProtectedRoute";
 
 const router = createBrowserRouter([
   {
@@ -33,7 +34,6 @@ const router = createBrowserRouter([
           },
         ],
       },
-
       {
         path: "/",
         element: <HomePage />,
@@ -43,16 +43,22 @@ const router = createBrowserRouter([
         element: <DetailPage />,
       },
       {
+        element: <AdminProtectedRoute />,
+        children: [
+          {
+            path: "/admin/:path",
+            element: <AdminPage />,
+          },
+        ],
+      },
+      {
         element: <ProtectedRoute />,
         children: [
           {
             path: "/algorithm-solving/:id",
             element: <AlgorithmSolvingPage />,
           },
-          {
-            path: "/admin/:path",
-            element: <AdminPage />,
-          },
+
           {
             path: "/complete",
             element: <CompletePage />,

--- a/idearly/src/services/apis/mswApi/handlers.ts
+++ b/idearly/src/services/apis/mswApi/handlers.ts
@@ -188,34 +188,17 @@ export const handlers = [
       return HttpResponse.json({
         status: "success",
         data: {
-          teamId: 123,
-          teamName: "snow",
-          competitionId: 1,
-          competitionName: "알고리즘 대회 이름",
-          leaderName: "이름1",
-          leaderEmail: "aaa@naver.com",
-          teammates: [
-            {
-              name: "이름1",
-              email: "aaa@naver.com",
-              inviteStatus: "accept"
-            },
-            {
-              name: "이름2",
-              email: "bbb@naver.com",
-              inviteStatus: "accept"
-            },
-            {
-              name: "이름3",
-              email: "ccc@naver.com",
-              inviteStatus: "accept"
-            }
-          ]
+          teamId: teamId,
+          accept: true
         }
       });
     } else {
       return HttpResponse.json({
-        status: "success"
+        status: "success",
+        data: {
+          teamId: teamId,
+          accept: false
+        }
       })
     }
   }),
@@ -228,7 +211,7 @@ export const handlers = [
     return HttpResponse.json({
       status: "success",
       data: {
-        teamId: 123,
+        teamId: teamId,
         teamName: "snow",
         competitionId: 1,
         competitionName: "알고리즘 대회 이름",

--- a/idearly/src/services/apis/mswApi/handlers.ts
+++ b/idearly/src/services/apis/mswApi/handlers.ts
@@ -1,118 +1,3 @@
-<<<<<<< Updated upstream
-// // src/mocks/handlers.ts
-// import { http, HttpResponse } from "msw";
-// import { IUserType } from "../../../pages/TeamMatchingPage/TeamMatchingPage.types";
-
-// const allPosts = new Map<number, IPost>();
-
-// export interface IPost {
-//   id: number,
-//   content: string,
-// }
-
-// export interface ICompetitionRequest {
-//   teamName: string,
-//   teammates: IUserType[],
-// }
-
-// interface IModifyUser {
-//   name: string
-// }
-// export const handlers = [
-//   // http.get('/posts', async ({ request }) => {
-
-//   //   const newPost: IPost = await request.json() as IPost;
-//   //   allPosts.set(newPost.id, newPost);
-//   //   console.log('Captured a "GET /posts" request')
-//   //   return HttpResponse.json(Array.from(allPosts.values()))
-
-//   // }),
-//   http.post('https://idearly.site/api/posts', async ({ request }) => {
-
-//     const temp = await request.json();
-//     console.log('Captured a "GET /posts" request', temp);
-//     return HttpResponse.json(Array.from(allPosts.values()))
-
-//   }),
-
-//   // 팀 생성
-//   http.post(`https://idearly.site/api/competitions/:competitionId`, async ({ request, params }) => {
-//     const { competitionId } = params;
-//     const nextPost: ICompetitionRequest = await request.json() as ICompetitionRequest;
-//     console.log('Updating post "%s" with:', competitionId, nextPost);
-//     if (nextPost.teamName === '함박눈') return new HttpResponse('중복된 이름입니다', {
-//       status: 409,
-//     });
-//     return HttpResponse.json();
-//   }),
-
-//   // 이메일로 회원 조회
-//   http.get(`https://idearly.site/api/competitions/:competitionId/members`, async ({ params, request }) => {
-//     const { competitionId } = params;
-//     console.log('competitionId: ', competitionId);
-
-//     const url = new URL(request.url)
-//     const email = url.searchParams.get('email')
-
-//     console.log('Updating get "%s" with:', email);
-//     if (email === 'aaa@naver.com') {
-//       return HttpResponse.json({
-//         status: "success",
-//         data: {
-//           exist: true,
-//           memberName: "이영민",
-//           email: "aaa@naver.com",
-//           invitable: true
-//         }
-//       });
-//     }
-//     if (email === 'bbb@naver.com') {
-//       return HttpResponse.json({
-//         status: "success",
-//         data: {
-//           exist: true,
-//           memberName: "강윤지",
-//           email: "bbb@naver.com",
-//           invitable: true
-//         }
-//       });
-//     }
-//     // else 
-//     return HttpResponse.json({
-//       status: "success",
-//       data: {
-//         exist: false,
-//       }
-//     });
-
-//   }),
-
-//   // 회원 탈퇴
-//   http.delete(`https://idearly.site/api/members`, async () => {
-//     console.log('회원 탈퇴');
-//     return HttpResponse.json({
-//       status: "success",
-//     });
-//   }),
-
-//   // 회원 정보 수정
-//   http.patch(`https://idearly.site/api/members`, async ({ request }) => {
-//     console.log('회원 정보 수정');
-
-//     // 숫자는 성공하는데, 영어나 한글은 실패하는 이슈 발생
-//     const temp: IModifyUser = await request.json() as IModifyUser;
-//     console.log('Captured a "patch /api/members" request', temp);
-
-//     return HttpResponse.json({
-//       status: "success",
-//       data: {
-//         email: "aaa@naver.com",
-//         name: temp,
-//       }
-//     });
-//   }),
-// ]
-=======
 // [msw] src/mocks/handlers.ts
 import { http, HttpResponse } from "msw";
 import { IUserType } from "../../../pages/TeamMatchingPage/TeamMatchingPage.types";
@@ -290,8 +175,88 @@ export const handlers = [
         }
       });
     }
-    
   }),
-]
->>>>>>> Stashed changes
+
+
+
+  // 마이페이지 - 팀 요청 수락 / 거절
+  http.post(`https://idearly.site/api/teams/:teamId`, async ({ request, params }) => {
+    const { teamId } = params;
+    const {accept} = await request.json() as REQ;
+    console.log('teamId', teamId, 'accept: ', accept);
+    if (accept){
+      return HttpResponse.json({
+        status: "success",
+        data: {
+          teamId: 123,
+          teamName: "snow",
+          competitionId: 1,
+          competitionName: "알고리즘 대회 이름",
+          leaderName: "이름1",
+          leaderEmail: "aaa@naver.com",
+          teammates: [
+            {
+              name: "이름1",
+              email: "aaa@naver.com",
+              inviteStatus: "accept"
+            },
+            {
+              name: "이름2",
+              email: "bbb@naver.com",
+              inviteStatus: "accept"
+            },
+            {
+              name: "이름3",
+              email: "ccc@naver.com",
+              inviteStatus: "accept"
+            }
+          ]
+        }
+      });
+    } else {
+      return HttpResponse.json({
+        status: "success"
+      })
+    }
+  }),
+
+  // 특정 팀 조회
+  http.get(`https://idearly.site/api/teams/:teamId`, async ({ params }) => {
+    const { teamId } = params;
+    console.log('teamId: ', teamId);
+
+    return HttpResponse.json({
+      status: "success",
+      data: {
+        teamId: 123,
+        teamName: "snow",
+        competitionId: 1,
+        competitionName: "알고리즘 대회 이름",
+        leaderName: "이름1",
+        leaderEmail: "aaa@naver.com",
+        teammates: [
+          {
+            name: "이름1",
+            email: "aaa@naver.com",
+            inviteStatus: "accept"
+          },
+          {
+            name: "이름2",
+            email: "bbb@naver.com",
+            inviteStatus: "accept"
+          },
+          {
+            name: "이름3",
+            email: "ccc@naver.com",
+            inviteStatus: "invite"
+          }
+        ]
+      }
+    });
+
+  }),]
+
+interface REQ {
+  accept: boolean,
+}
 

--- a/idearly/src/services/apis/mswApi/handlers.ts
+++ b/idearly/src/services/apis/mswApi/handlers.ts
@@ -206,7 +206,7 @@ export const handlers = [
   // 특정 팀 조회
   http.get(`https://idearly.site/api/teams/:teamId`, async ({ params }) => {
     const { teamId } = params;
-    console.log('teamId: ', teamId, teamId == '123');
+
     if (teamId == '123') {
       return HttpResponse.json({
         status: "success",

--- a/idearly/src/services/apis/mswApi/handlers.ts
+++ b/idearly/src/services/apis/mswApi/handlers.ts
@@ -266,9 +266,14 @@ export const handlers = [
         }
       });
     }
- 
+  }),
 
-  }),]
+  http.patch(`https://idearly.site/api/teams/:teamId`, async ({ params }) => {
+    const { teamId } = params;
+
+    return HttpResponse.json()
+  })
+]
 
 interface REQ {
   accept: boolean,

--- a/idearly/src/services/apis/mswApi/handlers.ts
+++ b/idearly/src/services/apis/mswApi/handlers.ts
@@ -1,3 +1,4 @@
+<<<<<<< Updated upstream
 // // src/mocks/handlers.ts
 // import { http, HttpResponse } from "msw";
 // import { IUserType } from "../../../pages/TeamMatchingPage/TeamMatchingPage.types";
@@ -111,4 +112,186 @@
 //     });
 //   }),
 // ]
+=======
+// [msw] src/mocks/handlers.ts
+import { http, HttpResponse } from "msw";
+import { IUserType } from "../../../pages/TeamMatchingPage/TeamMatchingPage.types";
+
+const allPosts = new Map<number, IPost>();
+
+export interface IPost {
+  id: number,
+  content: string,
+}
+
+export interface ICompetitionRequest {
+  teamName: string,
+  teammates: IUserType[],
+}
+
+interface IModifyUser {
+  name: string
+}
+export const handlers = [
+  // http.get('/posts', async ({ request }) => {
+
+  //   const newPost: IPost = await request.json() as IPost;
+  //   allPosts.set(newPost.id, newPost);
+  //   console.log('Captured a "GET /posts" request')
+  //   return HttpResponse.json(Array.from(allPosts.values()))
+
+  // }),
+  http.post('https://idearly.site/api/posts', async ({ request }) => {
+
+    const temp = await request.json();
+    console.log('Captured a "GET /posts" request', temp);
+    return HttpResponse.json(Array.from(allPosts.values()))
+
+  }),
+
+  // 팀 생성
+  http.post(`https://idearly.site/api/competitions/:competitionId`, async ({ request, params }) => {
+    const { competitionId } = params;
+    const nextPost: ICompetitionRequest = await request.json() as ICompetitionRequest;
+    console.log('Updating post "%s" with:', competitionId, nextPost);
+    if (nextPost.teamName === '함박눈') return new HttpResponse('중복된 이름입니다', {
+      status: 409,
+    });
+    return HttpResponse.json();
+  }),
+
+  // 이메일로 회원 조회
+  http.get(`https://idearly.site/api/competitions/:competitionId/members`, async ({ params, request }) => {
+    const { competitionId } = params;
+    console.log('competitionId: ', competitionId);
+
+    const url = new URL(request.url)
+    const email = url.searchParams.get('email')
+
+    console.log('Updating get "%s" with:', email);
+    if (email === 'aaa@naver.com') {
+      return HttpResponse.json({
+        status: "success",
+        data: {
+          exist: true,
+          memberName: "이영민",
+          email: "aaa@naver.com",
+          invitable: true
+        }
+      });
+    }
+    if (email === 'bbb@naver.com') {
+      return HttpResponse.json({
+        status: "success",
+        data: {
+          exist: true,
+          memberName: "강윤지",
+          email: "bbb@naver.com",
+          invitable: true
+        }
+      });
+    }
+    // else 
+    return HttpResponse.json({
+      status: "success",
+      data: {
+        exist: false,
+      }
+    });
+
+  }),
+
+  // 회원 탈퇴
+  http.delete(`https://idearly.site/api/members`, async () => {
+    console.log('회원 탈퇴');
+    return HttpResponse.json({
+      status: "success",
+    });
+  }),
+
+  // 회원 정보 수정
+  http.patch(`https://idearly.site/api/members`, async ({ request }) => {
+    console.log('회원 정보 수정');
+
+    // 숫자는 성공하는데, 영어나 한글은 실패하는 이슈 발생
+    const temp: IModifyUser = await request.json() as IModifyUser;
+    console.log('Captured a "patch /api/members" request', temp);
+
+    return HttpResponse.json({
+      status: "success",
+      data: {
+        email: "aaa@naver.com",
+        name: temp,
+      }
+    });
+  }),
+
+  // 마이페이지 - 현재 팀 조회 
+  http.get(`https://idearly.site/api/teams`, async ({request}) => {
+    const url = new URL(request.url)
+    const invite = url.searchParams.get('invite')
+
+    console.log('invite === ', invite);
+    console.log('Updating get "%s" with: 마이페이지 현재 팀 조회');
+    if (invite === "true") {
+      return HttpResponse.json({
+        status: "success",
+        data: {
+          teams: [
+            {
+              teamId: 123,
+              teamName: "snow",
+              competitionId: 1,
+              competitionTitle: "대회1",
+              startDateTime: "2023-12-07T13:33:03.969Z",
+              endDateTime: "2023-12-08T13:33:03.969Z",
+              leaderName: "이름1",
+              leaderEmail: "aaa@naver.com"
+            },
+            {
+              teamId: 456,
+              teamName: "fluffy",
+              competitionId: 2,
+              competitionTitle: "대회2",
+              startDateTime: "2023-12-07T13:33:03.969Z",
+              endDateTime: "2023-12-08T13:33:03.969Z",
+              leaderName: "이름1",
+              leaderEmail: "aaa@naver.com"
+            }
+          ]
+        }
+      });
+    } else {
+      return HttpResponse.json({
+        status: "success",
+        data: {
+          teams: [
+            {
+              teamId: 1234,
+              teamName: "snow2",
+              competitionId: 1,
+              competitionTitle: "대회1",
+              startDateTime: "2023-12-07T13:33:03.969Z",
+              endDateTime: "2023-12-08T13:33:03.969Z",
+              leaderName: "이름1",
+              leaderEmail: "aaa@naver.com"
+            },
+            {
+              teamId: 4567,
+              teamName: "fluffy2",
+              competitionId: 2,
+              competitionTitle: "대회2",
+              startDateTime: "2023-12-07T13:33:03.969Z",
+              endDateTime: "2023-12-08T13:33:03.969Z",
+              leaderName: "이름1",
+              leaderEmail: "aaa@naver.com"
+            }
+          ]
+        }
+      });
+    }
+    
+  }),
+]
+>>>>>>> Stashed changes
 

--- a/idearly/src/services/apis/mswApi/handlers.ts
+++ b/idearly/src/services/apis/mswApi/handlers.ts
@@ -130,8 +130,8 @@ export const handlers = [
               competitionTitle: "대회1",
               startDateTime: "2023-12-07T13:33:03.969Z",
               endDateTime: "2023-12-08T13:33:03.969Z",
-              leaderName: "이름1",
-              leaderEmail: "aaa@naver.com"
+              leaderName: "강윤지",
+              leaderEmail: "dbswl701@naver.com"
             },
             {
               teamId: 456,
@@ -158,8 +158,8 @@ export const handlers = [
               competitionTitle: "대회1",
               startDateTime: "2023-12-07T13:33:03.969Z",
               endDateTime: "2023-12-08T13:33:03.969Z",
-              leaderName: "이름1",
-              leaderEmail: "aaa@naver.com"
+              leaderName: "강윤지",
+              leaderEmail: "dbswl701@naver.com"
             },
             {
               teamId: 4567,
@@ -206,36 +206,67 @@ export const handlers = [
   // 특정 팀 조회
   http.get(`https://idearly.site/api/teams/:teamId`, async ({ params }) => {
     const { teamId } = params;
-    console.log('teamId: ', teamId);
-
-    return HttpResponse.json({
-      status: "success",
-      data: {
-        teamId: teamId,
-        teamName: "snow",
-        competitionId: 1,
-        competitionName: "알고리즘 대회 이름",
-        leaderName: "이름1",
-        leaderEmail: "aaa@naver.com",
-        teammates: [
-          {
-            name: "이름1",
-            email: "aaa@naver.com",
-            inviteStatus: "accept"
-          },
-          {
-            name: "이름2",
-            email: "bbb@naver.com",
-            inviteStatus: "accept"
-          },
-          {
-            name: "이름3",
-            email: "ccc@naver.com",
-            inviteStatus: "invite"
-          }
-        ]
-      }
-    });
+    console.log('teamId: ', teamId, teamId == '123');
+    if (teamId == '123') {
+      return HttpResponse.json({
+        status: "success",
+        data: {
+          teamId: teamId,
+          teamName: "snow",
+          competitionId: 1,
+          competitionName: "알고리즘 대회 이름",
+          leaderName: "강윤지",
+          leaderEmail: "dbswl701@naver.com",
+          teammates: [
+            {
+              name: "강윤지",
+              email: "dbswl701@naver.com",
+              inviteStatus: "accept"
+            },
+            {
+              name: "이름2",
+              email: "bbb@naver.com",
+              inviteStatus: "accept"
+            },
+            {
+              name: "이름3",
+              email: "ccc@naver.com",
+              inviteStatus: "invite"
+            }
+          ]
+        }
+      });
+    } else {
+      return HttpResponse.json({
+        status: "success",
+        data: {
+          teamId: teamId,
+          teamName: "snow",
+          competitionId: 1,
+          competitionName: "알고리즘 대회 이름",
+          leaderName: "이름1",
+          leaderEmail: "aaa@naver.com",
+          teammates: [
+            {
+              name: "이름12",
+              email: "aaa@naver.com",
+              inviteStatus: "accept"
+            },
+            {
+              name: "이름22",
+              email: "bbb@naver.com",
+              inviteStatus: "accept"
+            },
+            {
+              name: "이름32",
+              email: "ccc@naver.com",
+              inviteStatus: "invite"
+            }
+          ]
+        }
+      });
+    }
+ 
 
   }),]
 

--- a/idearly/src/services/apis/mypage.apis.ts
+++ b/idearly/src/services/apis/mypage.apis.ts
@@ -33,3 +33,10 @@ export const getTeamInfo = async (teamId: number) => {
   const response = await axiosInstance.get(`/api/teams/${teamId}`);
   return response.data;
 }
+
+// 팀원 수정 요청
+export const ModifyTeamMembers = async (teamId: number, payload: any) => {
+  console.log('payload 확인:', payload);
+  const response = await axiosInstance.patch(`api/teams/${teamId}`, payload);
+  return response.data;
+}

--- a/idearly/src/services/apis/mypage.apis.ts
+++ b/idearly/src/services/apis/mypage.apis.ts
@@ -9,3 +9,15 @@ export const withdrawalUser = async () => {
 export const modifyUser = async (name: string) => {
   return await axiosInstance.patch("/api/members", {name});
 }
+
+// 현재 팀 조회 - 참가 대회 소속팀 조회 요청
+export const getCurrentTeam = async () => {
+  const response = await axiosInstance.get("/api/teams?invite=true");
+  return response.data;
+}
+
+// 현재 팀 조회 - 대기중인 초대 현황 조회 요청
+export const getCWaitTeam = async () => {
+  const response = await axiosInstance.get("/api/teams?invite=false");
+  return response.data;
+}

--- a/idearly/src/services/apis/mypage.apis.ts
+++ b/idearly/src/services/apis/mypage.apis.ts
@@ -23,7 +23,13 @@ export const getCWaitTeam = async () => {
 }
 
 // 팀 초대 요청 수락 / 거절
-export const HandleInvite = async (teamId:number, isAccept: boolean) => {
+export const handleInvite = async (teamId:number, isAccept: boolean) => {
   const resposne = await axiosInstance.post(`/api/teams/${teamId}`, {accept: isAccept});
   return resposne.data;
+}
+
+// 특정 팀 정보 조회
+export const getTeamInfo = async (teamId: number) => {
+  const response = await axiosInstance.get(`/api/teams/${teamId}`);
+  return response.data;
 }

--- a/idearly/src/services/apis/mypage.apis.ts
+++ b/idearly/src/services/apis/mypage.apis.ts
@@ -21,3 +21,9 @@ export const getCWaitTeam = async () => {
   const response = await axiosInstance.get("/api/teams?invite=false");
   return response.data;
 }
+
+// 팀 초대 요청 수락 / 거절
+export const HandleInvite = async (teamId:number, isAccept: boolean) => {
+  const resposne = await axiosInstance.post(`/api/teams/${teamId}`, {accept: isAccept});
+  return resposne.data;
+}

--- a/idearly/src/store/MyPage.atoms.ts
+++ b/idearly/src/store/MyPage.atoms.ts
@@ -1,0 +1,6 @@
+import { atom } from "jotai";
+import { ITeam } from "../pages/MyPage/components/MyPgaeCurrentTeam/MyPageCurrentTeam.types";
+
+export const curTeamAtom = atom<ITeam[]>([]);
+
+export const waitTeamAtom = atom<ITeam[]>([]);

--- a/idearly/src/store/UserInfo.atoms.ts
+++ b/idearly/src/store/UserInfo.atoms.ts
@@ -1,8 +1,9 @@
 import { atomWithStorage } from "jotai/utils";
 
 export const userInfoAtom = atomWithStorage("userInfo", {
-  memberId: '',
-  email: '',
-  name: '',
+  authority: "",
+  memberId: "",
+  email: "",
+  name: "",
   isLogin: false,
 });

--- a/idearly/src/store/index.ts
+++ b/idearly/src/store/index.ts
@@ -1,3 +1,4 @@
 export * from "./AdminPage.atoms";
 export * from "./UserInfo.atoms";
 export * from "./HomePage.atoms";
+export * from "./MyPage.atoms";

--- a/idearly/src/types/index.ts
+++ b/idearly/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from "./user.types";
 export * from "./competition.types";
+export * from "./team.types";

--- a/idearly/src/types/team.types.ts
+++ b/idearly/src/types/team.types.ts
@@ -1,0 +1,4 @@
+export interface IReqTeamMember {
+  name: string,
+  email: string,
+}


### PR DESCRIPTION
## 이슈 번호
ID-20
- 📌

## 작업 분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 기타

## 작업 상세 내용
- 마이페이지 현재 팀 조회 페이지의 현재 팀 목록, 수락 대기 요청 목록 불러오는 api 연동
- 수락 대기 요청 수락 / 거절 api 연동
- 특정 팀 상세 조회 api 연동

## 다음 할 일
- 팀 매칭 페이지 대회 id 받아오기

## 체크 리스트

- [x] main 브랜치 pull 받기
- [x] 아직 작업 중인 파일은 올리지 않기

## 질문 사항

💬 **질문이 있어요!**

🔴 **이건 반드시 확인해 주세요!**
